### PR TITLE
feat: add blockchainEvent type and bump

### DIFF
--- a/packages/protocol-types/package.json
+++ b/packages/protocol-types/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/protocol-types",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "type": "commonjs"
 }

--- a/packages/protocol-types/src/lib/blockchainEvent.ts
+++ b/packages/protocol-types/src/lib/blockchainEvent.ts
@@ -1,0 +1,19 @@
+export interface BlockchainEvent {
+  returnValues: {
+    [key: string]: unknown;
+  };
+  raw: {
+    data: string;
+    topics: string[];
+  };
+  event: string;
+  signature: string;
+  logIndex: number;
+  transactionIndex: number;
+  transactionHash: string;
+  blockHash: string;
+  blockNumber: number;
+  address: string;
+  chainId: number;
+  network: string;
+}


### PR DESCRIPTION
We need the type on wallet-api but we also want the users of the wallet library to be able to access the type, hence it should be in `@arianee/protocol-types` and not in `wallet-api`