### PR TITLE
fix(apg): remove commonjs type to prevent issue with angular & webpack

### DIFF
--- a/packages/arianee-privacy-gateway-client/package.json
+++ b/packages/arianee-privacy-gateway-client/package.json
@@ -1,5 +1,4 @@
 {
   "name": "@arianee/arianee-privacy-gateway-client",
-  "version": "0.0.1",
-  "type": "commonjs"
+  "version": "0.0.2"
 }

--- a/packages/arianee-privacy-gateway-client/src/index.ts
+++ b/packages/arianee-privacy-gateway-client/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/arianee-privacy-gateway-client';
-export { default as ArianeePrivacyGatewayClient } from './lib/arianee-privacy-gateway-client';
+import ArianeePrivacyGatewayClient from './lib/arianee-privacy-gateway-client';
+export { ArianeePrivacyGatewayClient };


### PR DESCRIPTION
type: commonjs is the default value for node so it doesn't need to be specified, and specifying it seems to cause issue with angular & webpack

see https://github.com/typeorm/typeorm/pull/8688/files