### PR TITLE
Feat/optional fetch like apgc

### DIFF
--- a/packages/arianee-privacy-gateway-client/package.json
+++ b/packages/arianee-privacy-gateway-client/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-privacy-gateway-client",
-  "version": "0.3.0"
+  "version": "0.4.0"
 }

--- a/packages/arianee-privacy-gateway-client/src/lib/arianee-privacy-gateway-client.spec.ts
+++ b/packages/arianee-privacy-gateway-client/src/lib/arianee-privacy-gateway-client.spec.ts
@@ -1,6 +1,11 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Core } from '@arianee/core';
 import ArianeePrivacyGatewayClient from './arianee-privacy-gateway-client';
 import _fetch from 'node-fetch';
+
+declare const global: {
+  window: { fetch: typeof fetch } | undefined;
+};
 
 jest.mock('node-fetch');
 
@@ -18,6 +23,28 @@ const messageId = '456';
 const eventId = '789';
 
 describe('arianeePrivacyGatewayClient', () => {
+  describe('constructor', () => {
+    it('should use node-fetch in node environment as default fetch function', () => {
+      const client = new ArianeePrivacyGatewayClient('');
+      expect(client['fetchLike']).toBe(_fetch);
+    });
+
+    it('should use window.fetch in browser environment as default fetch function', () => {
+      const mockedFetch = {
+        bind: jest.fn(() => global.window!.fetch),
+      } as unknown as typeof fetch;
+
+      global.window = {
+        fetch: mockedFetch,
+      };
+
+      const client = new ArianeePrivacyGatewayClient('');
+      expect(client['fetchLike']).toBe(mockedFetch);
+
+      delete global.window;
+    });
+  });
+
   describe('using a Core instance as auth', () => {
     let core: Core;
     let arianeePrivacyGatewayClient: ArianeePrivacyGatewayClient;

--- a/packages/arianee-privacy-gateway-client/src/lib/arianee-privacy-gateway-client.ts
+++ b/packages/arianee-privacy-gateway-client/src/lib/arianee-privacy-gateway-client.ts
@@ -16,14 +16,21 @@ export type Authentication =
 
 export default class ArianeePrivacyGatewayClient {
   private aat?: ArianeeAccessTokenClass;
+  private readonly fetchLike: typeof fetch;
 
   constructor(
     private readonly auth:
       | Core
       | ArianeeAccessToken
       | { message: string; signature: string },
-    private readonly fetchLike: typeof fetch
-  ) {}
+    fetchLike?: typeof fetch
+  ) {
+    if (typeof window === 'undefined') {
+      this.fetchLike = fetchLike ?? require('node-fetch');
+    } else {
+      this.fetchLike = fetchLike ?? window.fetch.bind(window);
+    }
+  }
 
   private async getArianeeAccessToken(): Promise<ArianeeAccessToken> {
     if (this.auth instanceof Core) {


### PR DESCRIPTION
fetchLike is optional in all of our libs except arianee-privacy-gateway-client, so I've made it optional for consistency  