### PR TITLE
feat(wallet): allow passing aat in constructor + add authenticate method

### DIFF
--- a/apps/arianee-react-wallet/src/app/app.tsx
+++ b/apps/arianee-react-wallet/src/app/app.tsx
@@ -21,13 +21,17 @@ export function App() {
   );
 
   useEffect(() => {
-    setWallet(wallets[chainType]);
+    (async () => {
+      const wallet = wallets[chainType];
+      await wallet.authenticate();
+      setWallet(wallet);
+    })();
   }, [chainType]);
 
   return (
     <>
       {!wallet ? (
-        <div>Loading...</div>
+        <div>Loading ({chainType})...</div>
       ) : (
         <>
           <WalletHeader wallet={wallet} setChainType={setChainTypeCallback} />

--- a/apps/arianee-react-wallet/src/app/components/walletHeader.tsx
+++ b/apps/arianee-react-wallet/src/app/components/walletHeader.tsx
@@ -10,28 +10,39 @@ export default function WalletHeader({
   wallet,
   setChainType,
 }: WalletHeaderProps) {
+  const authenticate = async () => {
+    await wallet.authenticate();
+    alert('authenticated');
+  };
+
   const nextChainType = wallet.chainType === 'testnet' ? 'mainnet' : 'testnet';
 
   return (
     <div>
-      <strong>Wallet:</strong> {wallet.getAddress()}
-      <br />
-      <strong>Chain type:</strong>{' '}
-      {nextChainType === 'testnet' ? (
-        <a href="#" onClick={() => setChainType(nextChainType)}>
-          testnet
+      <div>
+        <strong>Wallet:</strong> {wallet.getAddress()} (
+        <a href="#" onClick={authenticate}>
+          authenticate
         </a>
-      ) : (
-        <a>testnet</a>
-      )}{' '}
-      /{' '}
-      {nextChainType === 'mainnet' ? (
-        <a href="#" onClick={() => setChainType(nextChainType)}>
-          mainnet
-        </a>
-      ) : (
-        <a>mainnet</a>
-      )}
+        )
+        <br />
+        <strong>Chain type:</strong>{' '}
+        {nextChainType === 'testnet' ? (
+          <a href="#" onClick={() => setChainType(nextChainType)}>
+            testnet
+          </a>
+        ) : (
+          <a>testnet</a>
+        )}{' '}
+        /{' '}
+        {nextChainType === 'mainnet' ? (
+          <a href="#" onClick={() => setChainType(nextChainType)}>
+            mainnet
+          </a>
+        ) : (
+          <a>mainnet</a>
+        )}
+      </div>
       <ul>
         <li>
           <a href="#nfts">NFTs</a>

--- a/apps/arianee-react-wallet/src/app/utils/wallet.ts
+++ b/apps/arianee-react-wallet/src/app/utils/wallet.ts
@@ -2,29 +2,36 @@ import Wallet from '@arianee/wallet';
 import Core from '@arianee/core';
 import WalletApiClient from '@arianee/wallet-api-client';
 import { ChainType } from '@arianee/common-types';
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
 
 const mnemonic =
   'sunset setup moral spoil stomach flush document expand rent siege perfect gauge';
 
 const core = Core.fromMnemonic(mnemonic);
 
+const arianeeAccessToken = new ArianeeAccessToken(core);
+
 const testnetWalletApiClient = new WalletApiClient('testnet', core, {
   apiURL: 'http://127.0.0.1:3000/',
+  arianeeAccessToken,
 });
 
 const testnetWallet = new Wallet({
   auth: { mnemonic },
   walletAbstraction: testnetWalletApiClient,
+  arianeeAccessToken,
 });
 
 const mainnetWalletApiClient = new WalletApiClient('mainnet', core, {
   apiURL: 'http://127.0.0.1:3000/',
+  arianeeAccessToken,
 });
 
 const mainnetWallet = new Wallet({
   auth: { core },
   walletAbstraction: mainnetWalletApiClient,
   chainType: 'mainnet',
+  arianeeAccessToken,
 });
 
 export const wallets: Record<ChainType, Wallet<ChainType>> = {

--- a/apps/arianee-react-wallet/src/main.tsx
+++ b/apps/arianee-react-wallet/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 
 import App from './app/app';
@@ -6,8 +5,4 @@ import App from './app/app';
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
-root.render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+root.render(<App />);

--- a/packages/wallet-api-client/package.json
+++ b/packages/wallet-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arianee/wallet-api-client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "dependencies": {
     "node-fetch": "^2.6.7"
   }

--- a/packages/wallet-api-client/src/lib/helpers/httpClient.spec.ts
+++ b/packages/wallet-api-client/src/lib/helpers/httpClient.spec.ts
@@ -2,6 +2,7 @@
 import { Core } from '@arianee/core';
 import _fetch from 'node-fetch';
 import HttpClient from './httpClient';
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
 
 jest.mock('node-fetch');
 
@@ -14,9 +15,15 @@ const core = Core.fromMnemonic(
 
 describe('httpClient', () => {
   let httpClient: HttpClient;
+  let arianeeAccessToken: ArianeeAccessToken;
   beforeEach(() => {
     jest.clearAllMocks();
-    httpClient = new HttpClient(core, mockedFetch as unknown as typeof fetch);
+    arianeeAccessToken = new ArianeeAccessToken(Core.fromRandom());
+    httpClient = new HttpClient(
+      core,
+      mockedFetch as unknown as typeof fetch,
+      arianeeAccessToken
+    );
   });
 
   describe('get', () => {

--- a/packages/wallet-api-client/src/lib/helpers/httpClient.ts
+++ b/packages/wallet-api-client/src/lib/helpers/httpClient.ts
@@ -6,11 +6,11 @@ export type AuthorizationType =
   | 'arianeeAccessToken';
 
 export default class HttpClient {
-  private arianeeAccessToken: ArianeeAccessToken;
-
-  constructor(private core: Core, private fetchLike: typeof fetch) {
-    this.arianeeAccessToken = new ArianeeAccessToken(this.core);
-  }
+  constructor(
+    private core: Core,
+    private fetchLike: typeof fetch,
+    private arianeeAccessToken: ArianeeAccessToken
+  ) {}
 
   private async getAuthorization(authorizationType: AuthorizationType) {
     let authorization: string;

--- a/packages/wallet-api-client/src/lib/walletApiClient.spec.ts
+++ b/packages/wallet-api-client/src/lib/walletApiClient.spec.ts
@@ -5,6 +5,7 @@ import _fetch from 'node-fetch';
 import { ChainType } from '@arianee/common-types';
 import { WALLET_API_URL } from './constants';
 import HttpClient from './helpers/httpClient';
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
 
 declare const global: {
   window: { fetch: typeof fetch } | undefined;
@@ -12,13 +13,19 @@ declare const global: {
 
 jest.mock('node-fetch');
 jest.mock('./helpers/httpClient');
+jest.mock('@arianee/arianee-access-token');
 
 const mockedFetch = _fetch as jest.MockedFunction<typeof _fetch>;
 
 const core = Core.fromMnemonic(
   'art success hello fold once ignore arrow damp note affair razor vital'
 );
-const httpClient = new HttpClient(core, mockedFetch as unknown as typeof fetch);
+const arianeeAccessToken = new ArianeeAccessToken(core);
+const httpClient = new HttpClient(
+  core,
+  mockedFetch as unknown as typeof fetch,
+  arianeeAccessToken
+);
 const mockedHttpClient = httpClient as jest.Mocked<HttpClient>;
 
 describe('WalletApiClient', () => {
@@ -411,6 +418,26 @@ describe('WalletApiClient', () => {
       });
 
       expect(client['httpClient']).toBe(httpClient);
+    });
+
+    it('should use the arianee access token instance if passed', () => {
+      const client = new WalletApiClient('testnet', core, {
+        arianeeAccessToken,
+      });
+
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        arianeeAccessToken
+      );
+    });
+
+    it('should instantiate arianee access token instance if not passed', () => {
+      const client = new WalletApiClient('testnet', core, {
+        httpClient,
+      });
+
+      expect(ArianeeAccessToken).toHaveBeenCalledWith(core);
     });
   });
 });

--- a/packages/wallet-api-client/src/lib/walletApiClient.ts
+++ b/packages/wallet-api-client/src/lib/walletApiClient.ts
@@ -11,6 +11,7 @@ import { Core } from '@arianee/core';
 import { WALLET_API_URL } from './constants';
 import { generateQueryString, removeTrailingSlash } from './helpers';
 import HttpClient, { AuthorizationType } from './helpers/httpClient';
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
 
 export default class WalletApiClient<T extends ChainType>
   implements WalletAbstraction
@@ -25,6 +26,7 @@ export default class WalletApiClient<T extends ChainType>
     options?: {
       apiURL?: string;
       httpClient?: HttpClient;
+      arianeeAccessToken?: ArianeeAccessToken;
     },
     fetchLike?: typeof fetch
   ) {
@@ -35,8 +37,13 @@ export default class WalletApiClient<T extends ChainType>
     }
 
     this.apiURL = removeTrailingSlash(options?.apiURL ?? WALLET_API_URL);
+
+    const arianeeAccessToken =
+      options?.arianeeAccessToken ?? new ArianeeAccessToken(this.core);
+
     this.httpClient =
-      options?.httpClient ?? new HttpClient(this.core, this.fetchLike);
+      options?.httpClient ??
+      new HttpClient(this.core, this.fetchLike, arianeeAccessToken);
   }
 
   private getAuthorizationType(

--- a/packages/wallet/README.md
+++ b/packages/wallet/README.md
@@ -17,7 +17,8 @@ Default values are:
 - `auth`: a randomly generated wallet using `@arianee/core`
 - `i18nStrategy`: `"raw"`
 - `fetchLike`: `window.fetch` in browser environment, `node-fetch` in node environment
-- `walletAbstraction`: a `WalletApiClient` instance from `@arianee/wallet-api-client`
+- `eventManagerParams`: undefined
+- `arianeeAccessToken`: a `ArianeeAccessToken` instance from `@arianee/arianee-access-token` using the core instance derived from passed auth
 
 First, you need to import the `Wallet` class:
 
@@ -85,6 +86,28 @@ const wallet = new Wallet({
 });
 ```
 
+### Arianee Access Token
+
+Sometimes you may want to use a custom `WalletApiClient` instance or your own arianee access token instance. In such case, make sure to use the same instance of `ArianeeAccessToken` both for the `WalletApiClient` instance and the `Wallet` instance. This way, the lib will request you to sign an arianee access token only once (it would request it twice if you don't share the instances).
+
+Example:
+
+```ts
+const core = Core.fromRandom();
+const arianeeAccessToken = new ArianeeAccessToken(core);
+
+const testnetWalletApiClient = new WalletApiClient('testnet', core, {
+  apiURL: 'http://127.0.0.1:3000/',
+  arianeeAccessToken,
+});
+
+const testnetWallet = new Wallet({
+  auth: { core },
+  walletAbstraction: testnetWalletApiClient,
+  arianeeAccessToken,
+});
+```
+
 ### Methods
 
 The wallet exposes several methods to interact with the Arianee protocol. \
@@ -120,7 +143,8 @@ wallet.identity.getOwnedSmartAssetsIdentities(...);
 wallet.identity.updated
 
 // utils
-wallet.getAddress()
+wallet.getAddress();
+wallet.authenticate(); // force generate a wallet scoped arianee access token, useful when you want to control when a signature request is made to the user with metamask / walletconnect etc.
 ```
 
 ### Events

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet",
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/packages/wallet/src/lib/wallet.spec.ts
+++ b/packages/wallet/src/lib/wallet.spec.ts
@@ -8,12 +8,14 @@ import IdentityService from './services/identity/identity';
 import SmartAssetService from './services/smartAsset/smartAsset';
 import MessageService from './services/message/message';
 import EventManager from './services/eventManager/eventManager';
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
 
 declare const global: {
   window: { fetch: typeof fetch } | undefined;
 };
 
 jest.mock('@arianee/core');
+jest.mock('@arianee/wallet-api-client');
 jest.mock('./services/identity/identity');
 jest.mock('./services/message/message');
 jest.mock('./services/smartAsset/smartAsset');
@@ -183,6 +185,33 @@ describe('Wallet', () => {
         expect.any(EventManager),
         'raw'
       );
+    });
+
+    it('should use the arianee access token instance if passed', () => {
+      jest.spyOn(Core, 'fromRandom').mockReturnValue({} as any);
+
+      const aat = new ArianeeAccessToken({} as any);
+
+      new Wallet({
+        arianeeAccessToken: aat,
+      });
+
+      expect(WalletApiClient).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        {
+          arianeeAccessToken: aat,
+        },
+        undefined
+      );
+    });
+
+    it('should instantiate arianee access token instance if not passed', () => {
+      jest.spyOn(Core, 'fromRandom').mockReturnValue({} as any);
+
+      const wallet = new Wallet();
+
+      expect(wallet['arianeeAccessToken']).toBeInstanceOf(ArianeeAccessToken);
     });
   });
 


### PR DESCRIPTION
No direct changes for the end user, wallet api client & wallet now use the same instance of ArianeeAccessToken by default and an `authenticate` method was added in wallet to allow force generation of a wallet scoped arianee access token (useful to trigger a metamask / walletconnect signature request prior to fetching content etc)

if you use a custom WalletApiClient, you need to do:
```ts
const core = Core.fromMnemonic(mnemonic);

const arianeeAccessToken = new ArianeeAccessToken(core);

const testnetWalletApiClient = new WalletApiClient('testnet', core, {
  apiURL: 'http://127.0.0.1:3000/',
  arianeeAccessToken,
});

const testnetWallet = new Wallet({
  auth: { mnemonic },
  walletAbstraction: testnetWalletApiClient,
  arianeeAccessToken,
});
```