### PR TITLE
fix(types): add a new type BrandIdentityWithOwned

### DIFF
--- a/apps/angular-wallet/src/app/components/wallet-identities/wallet-identities.component.ts
+++ b/apps/angular-wallet/src/app/components/wallet-identities/wallet-identities.component.ts
@@ -4,7 +4,7 @@ import Wallet, {
   IdentityInstance,
   IdentityUpdatedEvent,
 } from '@arianee/wallet';
-import { ChainType } from '@arianee/common-types';
+import { BrandIdentityWithOwned, ChainType } from '@arianee/common-types';
 
 @Component({
   selector: 'app-wallet-identities',
@@ -12,7 +12,7 @@ import { ChainType } from '@arianee/common-types';
   styleUrls: ['./wallet-identities.component.scss'],
 })
 export class WalletIdentities implements OnInit {
-  public identities: IdentityInstance[] = [];
+  public identities: IdentityInstance<BrandIdentityWithOwned>[] = [];
   public loading = false;
 
   public eventsLog = '';

--- a/apps/arianee-react-wallet/src/app/components/walletIdentities.tsx
+++ b/apps/arianee-react-wallet/src/app/components/walletIdentities.tsx
@@ -3,7 +3,7 @@ import Wallet, {
   IdentityUpdatedEvent,
 } from '@arianee/wallet';
 import { useEffect, useState } from 'react';
-import { ChainType } from '@arianee/common-types';
+import { BrandIdentityWithOwned, ChainType } from '@arianee/common-types';
 import { getTime } from '../utils/misc';
 
 export interface WalletIdentitiesProps {
@@ -11,7 +11,9 @@ export interface WalletIdentitiesProps {
 }
 
 export default function WalletIdentities({ wallet }: WalletIdentitiesProps) {
-  const [identities, setIdentities] = useState<IdentityInstance[]>([]);
+  const [identities, setIdentities] = useState<
+    IdentityInstance<BrandIdentityWithOwned>[]
+  >([]);
   const [loading, setLoading] = useState<boolean>(false);
 
   const [eventsLog, setEventsLog] = useState<string>('');

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/common-types",
-  "version": "0.8.0"
+  "version": "0.9.0"
 }

--- a/packages/common-types/src/lib/brandIdentity.ts
+++ b/packages/common-types/src/lib/brandIdentity.ts
@@ -9,5 +9,8 @@ export interface BrandIdentity {
   content: ArianeeBrandIdentityI18N;
   rawContent: ArianeeBrandIdentityI18N;
   protocol: Protocol;
+}
+
+export interface BrandIdentityWithOwned extends BrandIdentity {
   ownedCount: number;
 }

--- a/packages/wallet-abstraction/package.json
+++ b/packages/wallet-abstraction/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet-abstraction",
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/packages/wallet-abstraction/src/lib/walletAbstraction.ts
+++ b/packages/wallet-abstraction/src/lib/walletAbstraction.ts
@@ -1,5 +1,6 @@
 import {
   BrandIdentity,
+  BrandIdentityWithOwned,
   DecentralizedMessage,
   Event,
   Protocol,
@@ -55,5 +56,5 @@ export interface WalletAbstraction {
 
   getOwnedSmartAssetsBrandIdentities(params?: {
     preferredLanguages?: string[];
-  }): BrandIdentity[] | Promise<BrandIdentity[]>;
+  }): BrandIdentityWithOwned[] | Promise<BrandIdentityWithOwned[]>;
 }

--- a/packages/wallet-api-client/package.json
+++ b/packages/wallet-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arianee/wallet-api-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "dependencies": {
     "node-fetch": "^2.6.7"
   }

--- a/packages/wallet-api-client/src/lib/walletApiClient.ts
+++ b/packages/wallet-api-client/src/lib/walletApiClient.ts
@@ -1,6 +1,7 @@
 import { WalletAbstraction } from '@arianee/wallet-abstraction';
 import {
   BrandIdentity,
+  BrandIdentityWithOwned,
   ChainType,
   DecentralizedMessage,
   Event,
@@ -248,7 +249,7 @@ export default class WalletApiClient<T extends ChainType>
 
   async getOwnedSmartAssetsBrandIdentities(params?: {
     preferredLanguages?: string[];
-  }): Promise<BrandIdentity[]> {
+  }): Promise<BrandIdentityWithOwned[]> {
     const { preferredLanguages } = params || {};
 
     const query = generateQueryString({

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet",
-  "version": "0.3.0"
+  "version": "0.4.0"
 }

--- a/packages/wallet/src/lib/services/identity/identity.ts
+++ b/packages/wallet/src/lib/services/identity/identity.ts
@@ -1,11 +1,16 @@
-import { BrandIdentity, ChainType } from '@arianee/common-types';
+import {
+  BrandIdentity,
+  BrandIdentityWithOwned,
+  ChainType,
+} from '@arianee/common-types';
 import { WalletAbstraction } from '@arianee/wallet-abstraction';
 import { I18NStrategy, getPreferredLanguages } from '../../utils/i18n';
 import EventManager from '../eventManager/eventManager';
 
-export type IdentityInstance = {
-  data: BrandIdentity;
-};
+export type IdentityInstance<T extends BrandIdentity | BrandIdentityWithOwned> =
+  {
+    data: T;
+  };
 
 export default class IdentityService<T extends ChainType> {
   public readonly updated: EventManager<T>['identityUpdated'];
@@ -29,7 +34,7 @@ export default class IdentityService<T extends ChainType> {
     params?: {
       i18nStrategy?: I18NStrategy;
     }
-  ): Promise<IdentityInstance> {
+  ): Promise<IdentityInstance<BrandIdentity>> {
     const preferredLanguages = getPreferredLanguages(
       params?.i18nStrategy ?? this.i18nStrategy
     );
@@ -49,7 +54,7 @@ export default class IdentityService<T extends ChainType> {
    */
   async getOwnedSmartAssetsIdentities(params?: {
     i18nStrategy?: I18NStrategy;
-  }): Promise<IdentityInstance[]> {
+  }): Promise<IdentityInstance<BrandIdentityWithOwned>[]> {
     const { i18nStrategy } = params ?? {};
 
     const preferredLanguages = getPreferredLanguages(


### PR DESCRIPTION
The route for getting a single identity (without authentication etc) has no way to populate the `ownedCount` property as there is no owner / address information when calling it - therefore the type should not include this property if we don't fill it.

Solution: create a new type that will be used for `getOwnedSmartAssetsBrandIdentities ` with the `ownedCount` set.