### PR TITLE
fix(aat): do not perform expiration check in regeneration context

### DIFF
--- a/packages/arianee-access-token/package.json
+++ b/packages/arianee-access-token/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-access-token",
-  "version": "0.3.0"
+  "version": "0.3.1"
 }

--- a/packages/arianee-access-token/src/lib/arianee-access-token.ts
+++ b/packages/arianee-access-token/src/lib/arianee-access-token.ts
@@ -58,23 +58,31 @@ export class ArianeeAccessToken {
     return urlObject.toString();
   }
 
-  static isArianeeAccessTokenValid(arianeeAccessToken: string): boolean {
+  static isArianeeAccessTokenValid(
+    arianeeAccessToken: string,
+    ignoreExpiration = false
+  ): boolean {
     const recover = (message: string, signature: string): string =>
       ethers.verifyMessage(message, signature);
     const jwtGenerator = new JWTGeneric({ recover });
     const jwt = jwtGenerator.setToken(arianeeAccessToken);
     const iss = jwt.decode().payload.iss;
 
-    return jwt.verify(iss);
+    return jwt.verify(iss, ignoreExpiration);
   }
 
-  static decodeJwt(arianeeAccessToken: string): {
+  static decodeJwt(
+    arianeeAccessToken: string,
+    ignoreExpiration = false
+  ): {
     header: JwtHeaderInterface;
     payload: ArianeeAccessTokenPayload;
     signature: string;
   } {
-    const isAatValid =
-      ArianeeAccessToken.isArianeeAccessTokenValid(arianeeAccessToken);
+    const isAatValid = ArianeeAccessToken.isArianeeAccessTokenValid(
+      arianeeAccessToken,
+      ignoreExpiration
+    );
     if (!isAatValid) {
       throw new Error('ArianeeAccessToken is not valid');
     }

--- a/packages/arianee-access-token/src/lib/helpers/jwtGeneric.ts
+++ b/packages/arianee-access-token/src/lib/helpers/jwtGeneric.ts
@@ -70,7 +70,7 @@ export class JWTGeneric {
    * Verify if signature was signed by pubKey and return true/false
    * @param pubKey
    */
-  private verify(pubKey: string): boolean {
+  private verify(pubKey: string, ignoreExpiration = false): boolean {
     if (!this.params.recover) {
       throw new Error('You should provide a decoder to verify your token');
     }
@@ -83,7 +83,7 @@ export class JWTGeneric {
 
     const decode = this.params.recover(joinedHeaderPayload, signature);
 
-    const arePropertyValid = this.arePropertiesValid(payload);
+    const arePropertyValid = this.arePropertiesValid(payload, ignoreExpiration);
 
     if (!arePropertyValid) {
       return false;
@@ -91,8 +91,11 @@ export class JWTGeneric {
     return pubKey.toLowerCase() === decode.toLowerCase();
   }
 
-  private arePropertiesValid = (payload: ArianeeAccessTokenPayload) => {
-    if (payload.exp) {
+  private arePropertiesValid = (
+    payload: ArianeeAccessTokenPayload,
+    ignoreExpiration = false
+  ) => {
+    if (payload.exp && !ignoreExpiration) {
       const isExpired = new Date(payload.exp).getTime() < Date.now();
       if (isExpired) {
         return false;

--- a/packages/arianee-access-token/src/lib/helpers/timeBeforeExp.ts
+++ b/packages/arianee-access-token/src/lib/helpers/timeBeforeExp.ts
@@ -4,7 +4,7 @@ export function isExpInLessThan(
   aat: string,
   timeBeforeExpInSec: number
 ): boolean {
-  const decoded = ArianeeAccessToken.decodeJwt(aat);
+  const decoded = ArianeeAccessToken.decodeJwt(aat, true);
   const now = new Date().getTime();
   return decoded.payload.exp - now < timeBeforeExpInSec * 1000;
 }

--- a/packages/arianee-privacy-gateway-client/package.json
+++ b/packages/arianee-privacy-gateway-client/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-privacy-gateway-client",
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/packages/wallet-api-client/package.json
+++ b/packages/wallet-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arianee/wallet-api-client",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "dependencies": {
     "node-fetch": "^2.6.7"
   }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet",
-  "version": "0.4.0"
+  "version": "0.4.1"
 }


### PR DESCRIPTION
There was an issue where the method that checked if the AAT was about to expire (or expired) would check the validity of the AAT by verifying it had not expired.

So basically, new AAT generation only worked for cases where exp was in > 0 and < 10 seconds, if it was < 0, it threw because the JWT to be checked was expired.

Fix: do not check for expiration in regeneration context