### PR TITLE
feat: add support to link routes in wallet api client and wallet

### DIFF
--- a/apps/angular-wallet/tsconfig.json
+++ b/apps/angular-wallet/tsconfig.json
@@ -33,7 +33,8 @@
       "@arianee/wallet-abstraction": [
         "packages/wallet-abstraction/src/index.ts"
       ],
-      "@arianee/wallet-api-client": ["packages/wallet-api-client/src/index.ts"]
+      "@arianee/wallet-api-client": ["packages/wallet-api-client/src/index.ts"],
+      "@arianee/utils": ["packages/utils/src/index.ts"]
     }
   },
   "files": [],

--- a/apps/arianee-sdk-example/src/main.ts
+++ b/apps/arianee-sdk-example/src/main.ts
@@ -1,13 +1,15 @@
 // import certificateRead from './arianee-privacy-gateway-client/certificateRead';
 // import walletApiLanding from './wallet-api-client/landing';
 // import walletApiWallet from './wallet-api-client/wallet';
-
-import arianeeApiClient from './arianee-api-client/arianee-api-client';
+// import arianeeApiClient from './arianee-api-client/arianee-api-client';
+import links from './wallet-api-client/links';
 
 (async () => {
   // await certificateRead();
   // await walletApiLanding();
   // await walletApiWallet();
   // await wallet();
-  await arianeeApiClient();
+  // await arianeeApiClient();
+  // await arianeeApiClient();
+  await links();
 })();

--- a/apps/arianee-sdk-example/src/wallet-api-client/links.ts
+++ b/apps/arianee-sdk-example/src/wallet-api-client/links.ts
@@ -1,0 +1,29 @@
+import { Core } from '@arianee/core';
+import WalletApiClient from '@arianee/wallet-api-client';
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
+
+export default async () => {
+  const core = Core.fromPrivateKey(
+    '0x56b56751c357d857162301e9ffb4249bcf4269263afa7464fc4bf2de068c1de5'
+  );
+  const arianeeAccessToken = new ArianeeAccessToken(core);
+
+  const client = new WalletApiClient('testnet', core, {
+    apiURL: 'http://127.0.0.1:3000/',
+    arianeeAccessToken,
+  });
+
+  const linkDetails = await client.handleLink(
+    'https://test.arian.ee/47967078,wkauvo3mrny4'
+  );
+
+  const one2manyFinalLinkDetails = await client.handleLink(
+    'https://test.arian.ee/47967078,wkauvo3mrny4',
+    {
+      resolveFinalNft: true,
+      arianeeAccessToken: await arianeeAccessToken.getValidWalletAccessToken(),
+    }
+  );
+
+  console.log(linkDetails, one2manyFinalLinkDetails);
+};

--- a/packages/wallet-api-client/package.json
+++ b/packages/wallet-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arianee/wallet-api-client",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "dependencies": {
     "node-fetch": "^2.6.7"
   }

--- a/packages/wallet-api-client/src/lib/helpers/httpClient.spec.ts
+++ b/packages/wallet-api-client/src/lib/helpers/httpClient.spec.ts
@@ -88,4 +88,31 @@ describe('httpClient', () => {
       expect(res).toMatchObject({ mock: 'mock' });
     });
   });
+
+  describe('post', () => {
+    it('should call fetch with the right url and return the response', async () => {
+      const res = await httpClient.post(
+        'https://mock/',
+        {
+          mock: 'mock',
+        },
+        {
+          testHeader: 'testValue',
+        }
+      );
+
+      expect(mockedFetch).toHaveBeenCalledWith('https://mock/', {
+        method: 'POST',
+        body: JSON.stringify({ mock: 'mock' }),
+        headers: {
+          testHeader: 'testValue',
+          Accept: 'application/json, text/plain',
+          'Content-Type': 'application/json;charset=UTF-8',
+          mode: 'no-cors',
+        },
+      });
+
+      expect(res).toMatchObject({ mock: 'mock' });
+    });
+  });
 });

--- a/packages/wallet-api-client/src/lib/helpers/httpClient.ts
+++ b/packages/wallet-api-client/src/lib/helpers/httpClient.ts
@@ -62,4 +62,21 @@ export default class HttpClient {
       },
     });
   }
+
+  public async post(
+    url: string,
+    data: { [key: string | number]: unknown },
+    extraHeaders: HeadersInit = {}
+  ) {
+    return this.fetchLike(url, {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers: {
+        Accept: 'application/json, text/plain',
+        'Content-Type': 'application/json;charset=UTF-8',
+        mode: 'no-cors',
+        ...extraHeaders,
+      },
+    });
+  }
 }

--- a/packages/wallet-api-client/src/lib/walletApiClient.spec.ts
+++ b/packages/wallet-api-client/src/lib/walletApiClient.spec.ts
@@ -116,7 +116,7 @@ describe('WalletApiClient', () => {
         ok: false,
       } as unknown as Response);
 
-      expect(
+      await expect(
         walletApiClient.getSmartAsset('testnet', { id: '123456' })
       ).rejects.toThrowError(/error fetching/gi);
     });
@@ -183,7 +183,7 @@ describe('WalletApiClient', () => {
         ok: false,
       } as unknown as Response);
 
-      expect(
+      await expect(
         walletApiClient.getSmartAssetEvents('testnet', { id: '123456' })
       ).rejects.toThrowError(/error fetching/gi);
     });
@@ -232,7 +232,7 @@ describe('WalletApiClient', () => {
         ok: false,
       } as unknown as Response);
 
-      expect(walletApiClient.getOwnedSmartAssets()).rejects.toThrowError(
+      await expect(walletApiClient.getOwnedSmartAssets()).rejects.toThrowError(
         /error fetching/gi
       );
     });
@@ -268,7 +268,7 @@ describe('WalletApiClient', () => {
         ok: false,
       } as unknown as Response);
 
-      expect(walletApiClient.getReceivedMessages()).rejects.toThrowError(
+      await expect(walletApiClient.getReceivedMessages()).rejects.toThrowError(
         /error fetching/gi
       );
     });
@@ -304,9 +304,9 @@ describe('WalletApiClient', () => {
         ok: false,
       } as unknown as Response);
 
-      expect(walletApiClient.getMessage('1', 'testnet')).rejects.toThrowError(
-        /error fetching/gi
-      );
+      await expect(
+        walletApiClient.getMessage('1', 'testnet')
+      ).rejects.toThrowError(/error fetching/gi);
     });
   });
 
@@ -338,9 +338,9 @@ describe('WalletApiClient', () => {
         ok: false,
       } as unknown as Response);
 
-      expect(walletApiClient.getBrandIdentity('0x123456')).rejects.toThrowError(
-        /error fetching/gi
-      );
+      await expect(
+        walletApiClient.getBrandIdentity('0x123456')
+      ).rejects.toThrowError(/error fetching/gi);
     });
   });
   describe('getOwnedSmartAssetsBrandIdentities', () => {
@@ -370,9 +370,85 @@ describe('WalletApiClient', () => {
         ok: false,
       } as unknown as Response);
 
-      expect(
+      await expect(
         walletApiClient.getOwnedSmartAssetsBrandIdentities({})
       ).rejects.toThrowError(/error fetching/gi);
+    });
+  });
+
+  describe('handleLink', () => {
+    it('should call the api with the right url and return the data', async () => {
+      mockedHttpClient.post.mockResolvedValue({
+        ok: true,
+        json: async () => ({ mock: 'mock' }),
+      } as any);
+
+      const res = await walletApiClient.handleLink('https://mock', {
+        arianeeAccessToken: 'aat',
+        resolveFinalNft: true,
+      });
+
+      expect(mockedHttpClient.post).toHaveBeenCalledWith(
+        'https://mock/arianee/link/handle',
+        {
+          link: 'https://mock',
+          arianeeAccessToken: 'aat',
+          resolveFinalNft: true,
+        }
+      );
+
+      expect(res).toEqual({ mock: 'mock' });
+    });
+
+    it('should throw if response is not ok', async () => {
+      mockedHttpClient.post.mockResolvedValue({
+        ok: false,
+      } as unknown as Response);
+
+      await expect(
+        walletApiClient.handleLink('https://mock', {
+          arianeeAccessToken: 'aat',
+          resolveFinalNft: true,
+        })
+      ).rejects.toThrowError(/Failed to handle link/gi);
+    });
+  });
+
+  describe('linkToSmartAsset', () => {
+    it('should call the api with the right url and return the data', async () => {
+      mockedHttpClient.post.mockResolvedValue({
+        ok: true,
+        json: async () => ({ mock: 'mock' }),
+      } as any);
+
+      const res = await walletApiClient.linkToSmartAsset('https://mock', {
+        arianeeAccessToken: 'aat',
+        resolveFinalNft: true,
+      });
+
+      expect(mockedHttpClient.post).toHaveBeenCalledWith(
+        'https://mock/arianee/link/toSmartAsset',
+        {
+          link: 'https://mock',
+          arianeeAccessToken: 'aat',
+          resolveFinalNft: true,
+        }
+      );
+
+      expect(res).toEqual({ mock: 'mock' });
+    });
+
+    it('should throw if response is not ok', async () => {
+      mockedHttpClient.post.mockResolvedValue({
+        ok: false,
+      } as unknown as Response);
+
+      await expect(
+        walletApiClient.linkToSmartAsset('https://mock', {
+          arianeeAccessToken: 'aat',
+          resolveFinalNft: true,
+        })
+      ).rejects.toThrowError(/Failed to get smart asset from link/gi);
     });
   });
 

--- a/packages/wallet-api-client/src/lib/walletApiClient.ts
+++ b/packages/wallet-api-client/src/lib/walletApiClient.ts
@@ -13,6 +13,7 @@ import { WALLET_API_URL } from './constants';
 import { generateQueryString, removeTrailingSlash } from './helpers';
 import HttpClient, { AuthorizationType } from './helpers/httpClient';
 import { ArianeeAccessToken } from '@arianee/arianee-access-token';
+import { ReadLink } from '@arianee/utils';
 
 export default class WalletApiClient<T extends ChainType>
   implements WalletAbstraction
@@ -275,6 +276,66 @@ export default class WalletApiClient<T extends ChainType>
         `Failed to fetch owned smart assets brand identities: ${
           (e as Error).message
         }`
+      );
+    }
+  }
+
+  async handleLink(
+    link: string,
+    params?: {
+      resolveFinalNft?: boolean;
+      arianeeAccessToken?: string;
+    }
+  ): Promise<ReadLink> {
+    try {
+      const response = await this.httpClient.post(
+        `${this.apiURL}/arianee/link/handle`,
+        {
+          link,
+          ...(params?.resolveFinalNft && { resolveFinalNft: true }),
+          ...(params?.arianeeAccessToken && {
+            arianeeAccessToken: params.arianeeAccessToken,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`${response.statusText}`);
+      }
+
+      return await response.json();
+    } catch (e) {
+      throw new Error(`Failed to handle link: ${(e as Error).message}`);
+    }
+  }
+
+  async linkToSmartAsset(
+    link: string,
+    params?: {
+      resolveFinalNft?: boolean;
+      arianeeAccessToken?: string;
+    }
+  ): Promise<SmartAsset> {
+    try {
+      const response = await this.httpClient.post(
+        `${this.apiURL}/arianee/link/toSmartAsset`,
+        {
+          link,
+          ...(params?.resolveFinalNft && { resolveFinalNft: true }),
+          ...(params?.arianeeAccessToken && {
+            arianeeAccessToken: params.arianeeAccessToken,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`${response.statusText}`);
+      }
+
+      return await response.json();
+    } catch (e) {
+      throw new Error(
+        `Failed to get smart asset from link (${link}): ${(e as Error).message}`
       );
     }
   }

--- a/packages/wallet/README.md
+++ b/packages/wallet/README.md
@@ -119,7 +119,7 @@ const wallet = new Wallet();
 // smart asset methods
 wallet.smartAsset.get(...);
 wallet.smartAsset.getOwned(...);
-wallet.smartAsset.getFromLink(...); // to be implemented in subsequent versions
+wallet.smartAsset.getFromLink(...);
 
 // events
 wallet.smartAsset.received

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet",
-  "version": "0.5.2"
+  "version": "0.6.0"
 }

--- a/packages/wallet/src/lib/services/smartAsset/smartAsset.spec.ts
+++ b/packages/wallet/src/lib/services/smartAsset/smartAsset.spec.ts
@@ -2,8 +2,10 @@ import { Core } from '@arianee/core';
 import SmartAssetService from './smartAsset';
 import WalletApiClient from '@arianee/wallet-api-client';
 import EventManager from '../eventManager/eventManager';
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
 
 jest.mock('@arianee/wallet-api-client');
+jest.mock('@arianee/arianee-access-token');
 jest.mock('../eventManager/eventManager');
 
 const mockSmartAssetUpdated = {} as any;
@@ -29,7 +31,9 @@ const defaultI18nStrategy = {
 
 describe('SmartAssetService', () => {
   let smartAssetService: SmartAssetService<'testnet'>;
-  const walletApiClient = new WalletApiClient('testnet', Core.fromRandom());
+  const core = Core.fromRandom();
+  const walletApiClient = new WalletApiClient('testnet', core);
+  const arianeeAccessToken = new ArianeeAccessToken(core);
   const eventManager = new EventManager(
     'testnet',
     walletApiClient,
@@ -55,7 +59,8 @@ describe('SmartAssetService', () => {
     smartAssetService = new SmartAssetService(
       walletApiClient,
       eventManager,
-      defaultI18nStrategy
+      defaultI18nStrategy,
+      arianeeAccessToken
     );
   });
 
@@ -183,5 +188,106 @@ describe('SmartAssetService', () => {
         });
       }
     );
+  });
+  describe('getFromLink', () => {
+    it.each([
+      {
+        strategyName: 'default i18nStrategy',
+        i18nStrategy: undefined,
+      },
+      {
+        strategyName: 'params i18nStrategy',
+        i18nStrategy: {
+          useLanguages: ['te-ST'],
+        },
+      },
+    ])(
+      'should call walletApiClient.handleLink and call get with the correct params (using $strategyName)',
+      async ({ i18nStrategy }) => {
+        const mockGet = {
+          data: {
+            certificateId: '123',
+            protocol: {
+              name: 'testnet',
+              chainId: 1,
+            },
+          },
+          arianeeEvents: [],
+        };
+
+        const expectedI18NStrategy = i18nStrategy ?? defaultI18nStrategy;
+
+        const getSpy = jest
+          .spyOn(smartAssetService, 'get')
+          .mockResolvedValueOnce(mockGet as any);
+
+        const handleLinkSpy = jest
+          .spyOn(WalletApiClient.prototype, 'handleLink')
+          .mockResolvedValue({
+            certificateId: '123',
+            passphrase: 'abc',
+            network: 'testnet',
+            method: 'requestOwnership',
+            link: 'https://test.arian.ee/123,abc',
+          });
+
+        const getValidWalletAccessTokenSpy = jest
+          .spyOn(ArianeeAccessToken.prototype, 'getValidWalletAccessToken')
+          .mockResolvedValue('mockAccessToken');
+
+        const smartAsset = await smartAssetService.getFromLink(
+          'https://test.arian.ee/123,abc',
+          true,
+          i18nStrategy
+        );
+
+        expect(handleLinkSpy).toHaveBeenCalledWith(
+          'https://test.arian.ee/123,abc',
+          {
+            resolveFinalNft: true,
+            arianeeAccessToken: 'mockAccessToken',
+          }
+        );
+
+        expect(getValidWalletAccessTokenSpy).toHaveBeenCalled();
+        expect(getSpy).toHaveBeenCalledWith(
+          'testnet',
+          {
+            id: '123',
+            passphrase: 'abc',
+          },
+          {
+            i18nStrategy: expectedI18NStrategy,
+          }
+        );
+
+        expect(smartAsset).toEqual(mockGet);
+      }
+    );
+
+    it('should throw if the wallet abstraction is not a WalletApiClient', async () => {
+      const smartAssetService = new SmartAssetService(
+        {} as any,
+        eventManager,
+        defaultI18nStrategy,
+        arianeeAccessToken
+      );
+
+      await expect(
+        smartAssetService.getFromLink('https://test.arian.ee/123,abc')
+      ).rejects.toThrowError(
+        'The wallet abstraction you use do not support this method'
+      );
+    });
+
+    it('should throw if no smart asset can be retrieved from the link', async () => {
+      jest
+        .spyOn(WalletApiClient.prototype, 'handleLink')
+        .mockRejectedValue(new Error('mockError'));
+
+      await expect(
+        smartAssetService.getFromLink('https://test.arian.ee/123,abc')
+      ).rejects.toThrowError('Could not retrieve a smart asset from this link');
+    });
   });
 });

--- a/packages/wallet/src/lib/wallet.spec.ts
+++ b/packages/wallet/src/lib/wallet.spec.ts
@@ -16,6 +16,7 @@ declare const global: {
 
 jest.mock('@arianee/core');
 jest.mock('@arianee/wallet-api-client');
+jest.mock('@arianee/arianee-access-token');
 jest.mock('./services/identity/identity');
 jest.mock('./services/message/message');
 jest.mock('./services/smartAsset/smartAsset');
@@ -183,7 +184,8 @@ describe('Wallet', () => {
       expect(SmartAssetService).toHaveBeenCalledWith(
         expect.any(WalletApiClient),
         expect.any(EventManager),
-        'raw'
+        'raw',
+        wallet['arianeeAccessToken']
       );
     });
 

--- a/packages/wallet/src/lib/wallet.ts
+++ b/packages/wallet/src/lib/wallet.ts
@@ -78,7 +78,8 @@ export default class Wallet<T extends ChainType = 'testnet'> {
     this._smartAsset = new SmartAssetService(
       this.walletAbstraction,
       this.eventManager,
-      this.i18nStrategy
+      this.i18nStrategy,
+      this.arianeeAccessToken
     );
 
     this._identity = new IdentityService<T>(


### PR DESCRIPTION
![image](https://github.com/Arianee/arianee-sdk/assets/90714480/58b64646-1520-4974-82d2-195d3194e7a0)

You can test with the handle link buttons in the react wallet (with resolve = get the nft you claim behind a one2many, without = get the landing)