### PR TITLE
fix(types): separate BlockchainEvent from UnnestedBlockchainEvent

### DIFF
--- a/packages/arianee-api-client/src/lib/arianee-api-client.ts
+++ b/packages/arianee-api-client/src/lib/arianee-api-client.ts
@@ -5,6 +5,7 @@ import {
   ChainType,
   Protocol,
   SmartContractNames,
+  UnnestedBlockchainEvent,
 } from '@arianee/common-types';
 
 import { blockchainEventFilters } from './types/blockchainEventFilters';
@@ -53,7 +54,7 @@ export class ArianeeApiClient {
       smartContractName: SmartContractNames,
       eventName: blockchainEventsName,
       filters?: blockchainEventFilters
-    ): Promise<BlockchainEvent[]> => {
+    ): Promise<UnnestedBlockchainEvent[]> => {
       const queryParams = filters
         ? '?' + convertObjectToDotNotation(filters)
         : '';
@@ -101,7 +102,7 @@ export class ArianeeApiClient {
       contractAddress: string,
       eventName: blockchainEventsName,
       filters?: blockchainEventFilters
-    ): Promise<BlockchainEvent[]> => {
+    ): Promise<UnnestedBlockchainEvent[]> => {
       const queryParams = filters
         ? '?' + convertObjectToDotNotation(filters)
         : '';

--- a/packages/common-types/src/lib/blockchainEvent.ts
+++ b/packages/common-types/src/lib/blockchainEvent.ts
@@ -26,3 +26,11 @@ export interface BlockchainEvent {
   blockNumber: number;
   contractAddress: string;
 }
+
+export interface UnnestedBlockchainEvent extends EventData {
+  protocol: Protocol;
+  timestamp: string;
+  smartContractName: string;
+  blockNumber: number;
+  contractAddress: string;
+}

--- a/packages/wallet/src/lib/services/eventManager/eventManager.spec.ts
+++ b/packages/wallet/src/lib/services/eventManager/eventManager.spec.ts
@@ -2,7 +2,11 @@
 import EventManager from './eventManager';
 import Core from '@arianee/core';
 import WalletApiClient from '@arianee/wallet-api-client';
-import { BlockchainEvent, ChainType } from '@arianee/common-types';
+import {
+  BlockchainEvent,
+  ChainType,
+  UnnestedBlockchainEvent,
+} from '@arianee/common-types';
 
 jest.mock('@arianee/wallet-api-client');
 jest.mock('@arianee/core');
@@ -245,26 +249,23 @@ describe('EventManager', () => {
   describe('emitSmartAssetsEvents', () => {
     it('should emit smartAssetTransferred and smartAssetReceived events with correct data', async () => {
       const receivedEvent = {
-        eventData: {
-          returnValues: {
-            _from: '0x123',
-            _to: userAddress,
-            _tokenId: '1',
-          },
+        returnValues: {
+          _from: '0x123',
+          _to: userAddress,
+          _tokenId: '1',
         },
         protocol: { chainId: 1, name: 'mock' },
-      } as unknown as BlockchainEvent;
+      } as unknown as UnnestedBlockchainEvent;
 
       const transferredEvent = {
-        eventData: {
-          returnValues: {
-            _from: userAddress,
-            _to: '0x123',
-            _tokenId: '2',
-          },
+        returnValues: {
+          _from: userAddress,
+          _to: '0x123',
+          _tokenId: '2',
         },
+
         protocol: { chainId: 1, name: 'mock' },
-      } as unknown as BlockchainEvent;
+      } as unknown as UnnestedBlockchainEvent;
 
       const emitUniqueSpy = jest.spyOn(eventManager as any, 'emitUnique');
 
@@ -346,14 +347,12 @@ describe('EventManager', () => {
   describe('emitArianeeEvents', () => {
     it('should emit arianeeEventReceived events with correct data', async () => {
       const arianeeEvent = {
-        eventData: {
-          returnValues: {
-            _eventId: '2',
-            _tokenId: '1',
-          },
+        returnValues: {
+          _eventId: '2',
+          _tokenId: '1',
         },
         protocol: { chainId: 1, name: 'mock' },
-      } as unknown as BlockchainEvent;
+      } as unknown as UnnestedBlockchainEvent;
 
       const emitUniqueSpy = jest.spyOn(eventManager as any, 'emitUnique');
 
@@ -417,13 +416,11 @@ describe('EventManager', () => {
   describe('emitIdentitiesEvents', () => {
     it('should emit identityUpdated events with correct data', async () => {
       const identityEvent = {
-        eventData: {
-          returnValues: {
-            _identity: '0x1',
-          },
+        returnValues: {
+          _identity: '0x1',
         },
         protocol: { chainId: 1, name: 'mock' },
-      } as unknown as BlockchainEvent;
+      } as unknown as UnnestedBlockchainEvent;
 
       const emitUniqueSpy = jest.spyOn(eventManager as any, 'emitUnique');
 
@@ -486,13 +483,11 @@ describe('EventManager', () => {
   describe('emitMessagesEvents', () => {
     it('should emit messageReceived events with correct data', async () => {
       const messageEvent = {
-        eventData: {
-          returnValues: {
-            _messageId: '1',
-          },
+        returnValues: {
+          _messageId: '1',
         },
         protocol: { chainId: 1, name: 'mock' },
-      } as unknown as BlockchainEvent;
+      } as unknown as UnnestedBlockchainEvent;
 
       const emitUniqueSpy = jest.spyOn(eventManager as any, 'emitUnique');
 

--- a/packages/wallet/src/lib/services/eventManager/eventManager.ts
+++ b/packages/wallet/src/lib/services/eventManager/eventManager.ts
@@ -3,7 +3,7 @@ import { WalletAbstraction } from '@arianee/wallet-abstraction';
 import { EventMap } from './types/events';
 import WrappedEventEmitter from './helpers/wrappedEventEmitter';
 import {
-  BlockchainEvent,
+  UnnestedBlockchainEvent,
   BrandIdentity,
   ChainType,
   SmartAsset,
@@ -111,7 +111,7 @@ export default class EventManager<T extends ChainType>
   private emitUnique<E extends keyof EventMap>(
     eventName: E,
     event: EventMap[E],
-    rawEvent: BlockchainEvent
+    rawEvent: UnnestedBlockchainEvent
   ) {
     const _hashCode = hashCode(`${eventName}-${JSON.stringify(rawEvent)}`);
 
@@ -265,13 +265,13 @@ export default class EventManager<T extends ChainType>
     return messagesEvents;
   }
 
-  private async emitArianeeEvents(arianeeEvents: BlockchainEvent[]) {
+  private async emitArianeeEvents(arianeeEvents: UnnestedBlockchainEvent[]) {
     arianeeEvents.forEach((event) => {
       this.emitUnique(
         'arianeeEventReceived',
         {
-          certificateId: event.eventData.returnValues['_tokenId'] as string,
-          eventId: event.eventData.returnValues['_eventId'] as string,
+          certificateId: event.returnValues['_tokenId'] as string,
+          eventId: event.returnValues['_eventId'] as string,
           protocol: event.protocol,
         },
         event
@@ -280,13 +280,13 @@ export default class EventManager<T extends ChainType>
   }
 
   private async emitSmartAssetsEvents(smartAssetEvents: {
-    transferred: BlockchainEvent[];
-    received: BlockchainEvent[];
+    transferred: UnnestedBlockchainEvent[];
+    received: UnnestedBlockchainEvent[];
   }) {
     const { transferred, received } = smartAssetEvents;
 
     transferred.forEach((event) => {
-      const { _to, _tokenId } = event.eventData.returnValues;
+      const { _to, _tokenId } = event.returnValues;
 
       this.emitUnique(
         'smartAssetTransferred',
@@ -300,7 +300,7 @@ export default class EventManager<T extends ChainType>
     });
 
     received.forEach((event) => {
-      const { _from, _tokenId } = event.eventData.returnValues;
+      const { _from, _tokenId } = event.returnValues;
 
       this.emitUnique(
         'smartAssetReceived',
@@ -314,12 +314,14 @@ export default class EventManager<T extends ChainType>
     });
   }
 
-  private async emitIdentitiesEvents(identitiesEvents: BlockchainEvent[]) {
+  private async emitIdentitiesEvents(
+    identitiesEvents: UnnestedBlockchainEvent[]
+  ) {
     identitiesEvents.forEach((event) => {
       this.emitUnique(
         'identityUpdated',
         {
-          issuer: event.eventData.returnValues['_identity'] as string,
+          issuer: event.returnValues['_identity'] as string,
           protocol: event.protocol,
         },
         event
@@ -327,12 +329,12 @@ export default class EventManager<T extends ChainType>
     });
   }
 
-  private async emitMessagesEvents(messagesEvents: BlockchainEvent[]) {
+  private async emitMessagesEvents(messagesEvents: UnnestedBlockchainEvent[]) {
     messagesEvents.forEach((event) => {
       this.emitUnique(
         'messageReceived',
         {
-          messageId: event.eventData.returnValues['_messageId'] as string,
+          messageId: event.returnValues['_messageId'] as string,
           protocol: event.protocol,
         },
         event


### PR DESCRIPTION
![image](https://github.com/Arianee/arianee-sdk/assets/90714480/72064d19-38aa-46fc-8691-35718b807fc6)

create unnestedBlockchainEvent type to accommodate to the two types of blockchainEvent returned by arianee-api
