### PR TITLE
feat: add a transaction waiting strategy to creator

### DIFF
--- a/apps/angular-creator/src/app/components/actions/action-buy-credit/action-buy-credit.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-buy-credit/action-buy-credit.component.ts
@@ -10,7 +10,7 @@ import { getV2ContractAddressForCreditType } from '../../../helpers/getV2Contrac
   styleUrls: ['./action-buy-credit.component.scss'],
 })
 export class ActionBuyCreditComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public creditType: string = '0';
   public amount: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-create-and-store-event/action-create-and-store-event.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-create-and-store-event/action-create-and-store-event.component.ts
@@ -14,7 +14,7 @@ import { ArianeeEventI18N } from '@arianee/common-types';
 })
 export class ActionCreateAndStoreEventComponent implements Action {
   public result: string | null = null;
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public smartAssetId: string = '';
   public id: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-create-and-store-message/action-create-and-store-message.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-create-and-store-message/action-create-and-store-message.component.ts
@@ -17,7 +17,7 @@ import { ArianeeMessageI18N } from '../../../../../../../packages/common-types/s
 })
 export class ActionCreateAndStoreMessageComponent implements Action {
   public result: string | null = null;
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public smartAssetId: string = '';
   public id: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-create-and-store-smart-asset/action-create-and-store-smart-asset.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-create-and-store-smart-asset/action-create-and-store-smart-asset.component.ts
@@ -13,7 +13,7 @@ import { ArianeeProductCertificateI18N } from '../../../../../../../packages/com
   styleUrls: ['./action-create-and-store-smart-asset.component.scss'],
 })
 export class ActionCreateAndStoreSmartAssetComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public id: string | null = null;
   public content: string = JSON.stringify(

--- a/apps/angular-creator/src/app/components/actions/action-create-event/action-create-event.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-create-event/action-create-event.component.ts
@@ -13,7 +13,7 @@ import { Action } from '../action';
 })
 export class ActionCreateEventComponent implements Action {
   public result: string | null = null;
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public smartAssetId: string = '';
   public id: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-create-message/action-create-message.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-create-message/action-create-message.component.ts
@@ -13,7 +13,7 @@ import { Action } from '../action';
 })
 export class ActionCreateMessageComponent implements Action {
   public result: string | null = null;
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public smartAssetId: string = '';
   public id: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-create-smart-asset/action-create-smart-asset.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-create-smart-asset/action-create-smart-asset.component.ts
@@ -12,7 +12,7 @@ import { Action } from '../action';
   styleUrls: ['./action-create-smart-asset.component.scss'],
 })
 export class ActionCreateSmartAssetComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public id: string | null = null;
   public uri: string = '';

--- a/apps/angular-creator/src/app/components/actions/action-destroy-smart-asset/action-destroy-smart-asset-id.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-destroy-smart-asset/action-destroy-smart-asset-id.component.ts
@@ -8,7 +8,7 @@ import { Action } from '../action';
   styleUrls: ['./action-destroy-smart-asset-id.component.scss'],
 })
 export class ActionDestroySmartAssetIdComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public id: string | null = null;
   public result: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-get-aria-balance/action-get-aria-balance.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-get-aria-balance/action-get-aria-balance.component.ts
@@ -8,7 +8,7 @@ import { Action } from '../action';
   styleUrls: ['./action-get-aria-balance.component.scss'],
 })
 export class ActionGetAriaBalanceComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public creditType: string = '0';
   public result: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-get-available-smart-asset-id/action-get-available-smart-asset-id.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-get-available-smart-asset-id/action-get-available-smart-asset-id.component.ts
@@ -8,7 +8,7 @@ import { Action } from '../action';
   styleUrls: ['./action-get-available-smart-asset-id.component.scss'],
 })
 export class ActionGetAvailableSmartAssetIdComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public result: string | null = null;
   public loading = false;

--- a/apps/angular-creator/src/app/components/actions/action-get-credit-balance/action-get-credit-balance.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-get-credit-balance/action-get-credit-balance.component.ts
@@ -11,7 +11,7 @@ import { getV2ContractAddressForCreditType } from '../../../helpers/getV2Contrac
   styleUrls: ['./action-get-credit-balance.component.scss'],
 })
 export class ActionGetCreditBalance implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public id: string | null = null;
   public creditType: string = '0';

--- a/apps/angular-creator/src/app/components/actions/action-get-credit-price/action-get-credit-price.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-get-credit-price/action-get-credit-price.component.ts
@@ -9,7 +9,7 @@ import { isConnectedToV2Protocol } from '../../../helpers/isConnectedToV2Protoco
   styleUrls: ['./action-get-credit-price.component.scss'],
 })
 export class ActionGetCreditPriceComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public creditType: string = '0';
   public result: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-get-native-balance/action-get-native-balance.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-get-native-balance/action-get-native-balance.component.ts
@@ -8,7 +8,7 @@ import { Action } from '../action';
   styleUrls: ['./action-get-native-balance.component.scss'],
 })
 export class ActionGetNativeBalanceComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public result: string | null = null;
   public loading = false;

--- a/apps/angular-creator/src/app/components/actions/action-recover-smart-asset/action-recover-smart-asset-id.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-recover-smart-asset/action-recover-smart-asset-id.component.ts
@@ -8,7 +8,7 @@ import { Action } from '../action';
   styleUrls: ['./action-recover-smart-asset-id.component.scss'],
 })
 export class ActionRecoverSmartAssetIdComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public id: string | null = null;
   public result: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-request-testnet-aria20/action-request-testnet-aria20.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-request-testnet-aria20/action-request-testnet-aria20.component.ts
@@ -11,7 +11,7 @@ import { Action } from '../action';
   styleUrls: ['./action-request-testnet-aria20.component.scss'],
 })
 export class ActionRequestTestnetAria20Component implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public result: string | null = null;
   public loading = false;

--- a/apps/angular-creator/src/app/components/actions/action-reserve-smart-asset-id/action-reserve-smart-asset-id.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-reserve-smart-asset-id/action-reserve-smart-asset-id.component.ts
@@ -8,7 +8,7 @@ import { Action } from '../action';
   styleUrls: ['./action-reserve-smart-asset-id.component.scss'],
 })
 export class ActionReserveSmartAssetIdComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public id: string | null = null;
   public result: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-set-request-key/action-set-request-key.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-set-request-key/action-set-request-key.component.ts
@@ -8,7 +8,7 @@ import { Action } from '../action';
   styleUrls: ['./action-set-request-key.component.scss'],
 })
 export class ActionSetRequestKeyComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public id: string | null = null;
   public passphrase: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-update-identity/action-update-identity.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-update-identity/action-update-identity.component.ts
@@ -9,7 +9,7 @@ import { ArianeeBrandIdentityI18N } from '../../../../../../../packages/common-t
   styleUrls: ['./action-update-identity.component.scss'],
 })
 export class ActionUpdateIdentityComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public uri: string = '';
   public result: string | null = null;

--- a/apps/angular-creator/src/app/components/actions/action-update-smart-asset/action-update-smart-asset.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-update-smart-asset/action-update-smart-asset.component.ts
@@ -13,7 +13,7 @@ import { ArianeeProductCertificateI18N } from '@arianee/common-types';
 })
 export class ActionUpdateSmartAssetComponent implements Action {
   public result: string | null = null;
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public smartAssetId: string = '';
   public content: string = JSON.stringify(

--- a/apps/angular-creator/src/app/components/actions/action-update-token-uri/action-update-token-uri.component.ts
+++ b/apps/angular-creator/src/app/components/actions/action-update-token-uri/action-update-token-uri.component.ts
@@ -8,7 +8,7 @@ import { Action } from '../action';
   styleUrls: ['./action-update-token-uri.component.scss'],
 })
 export class ActionUpdateTokenURIComponent implements Action {
-  @Input() creator: Creator | null = null;
+  @Input() creator: Creator<'WAIT_TRANSACTION_RECEIPT'> | null = null;
 
   public id: string = '';
   public uri: string = '';

--- a/apps/angular-creator/src/app/helpers/getV2ContractAddressForCreditType.ts
+++ b/apps/angular-creator/src/app/helpers/getV2ContractAddressForCreditType.ts
@@ -3,7 +3,7 @@ import { ProtocolDetailsV2 } from '@arianee/arianee-protocol-client';
 
 export const getV2ContractAddressForCreditType = (
   creditType: number,
-  creator: Creator
+  creator: Creator<'WAIT_TRANSACTION_RECEIPT'>
 ): string => {
   const v2ProtocolDetails = creator.connectedProtocolClient
     ?.protocolDetails as ProtocolDetailsV2;

--- a/apps/angular-creator/src/app/helpers/isConnectedToV2Protocol.ts
+++ b/apps/angular-creator/src/app/helpers/isConnectedToV2Protocol.ts
@@ -1,6 +1,8 @@
 import Creator from '@arianee/creator';
 
-export const isConnectedToV2Protocol = (creator: Creator): boolean => {
+export const isConnectedToV2Protocol = (
+  creator: Creator<'WAIT_TRANSACTION_RECEIPT'>
+): boolean => {
   if (!creator.connectedProtocolClient)
     throw new Error('No protocol client connected');
 

--- a/apps/angular-creator/src/app/services/creator/creator.service.ts
+++ b/apps/angular-creator/src/app/services/creator/creator.service.ts
@@ -9,8 +9,8 @@ import { ProtocolDetails } from '@arianee/arianee-protocol-client';
   providedIn: 'root',
 })
 export class CreatorService {
-  private _creator: BehaviorSubject<Creator | null> =
-    new BehaviorSubject<Creator | null>(null);
+  private _creator: BehaviorSubject<Creator<'WAIT_TRANSACTION_RECEIPT'> | null> =
+    new BehaviorSubject<Creator<'WAIT_TRANSACTION_RECEIPT'> | null>(null);
 
   public get connected() {
     return this._creator.getValue()?.connected || false;
@@ -63,6 +63,7 @@ export class CreatorService {
       new Creator({
         core,
         creatorAddress,
+        transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
         fetchLike: (input, init) =>
           defaultFetchLike(input, {
             ...init,

--- a/apps/arianee-sdk-example/src/creator/createAndStore.ts
+++ b/apps/arianee-sdk-example/src/creator/createAndStore.ts
@@ -7,6 +7,7 @@ export default async () => {
   const creator = new Creator({
     core: Core.fromPrivateKey(process.env.PRIVATE_KEY),
     creatorAddress: '0x6C0084Bb281dcE6B0f0cc86191086531A50dDf04',
+    transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
   });
 
   await creator.connect('testnet');

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:all": "nx run-many --target=lint --all",
     "bump:all": "./scripts/bump.sh",
     "publish:all": "./scripts/publish.sh",
+    "link:all": "./scripts/link.sh",
     "dev": "nx serve arianee-sdk-example",
     "react-wallet": "nx serve arianee-react-wallet",
     "angular-wallet": "nx serve angular-wallet",

--- a/packages/arianee-protocol-client/src/lib/utils/ethersCustom/ethersCustom.ts
+++ b/packages/arianee-protocol-client/src/lib/utils/ethersCustom/ethersCustom.ts
@@ -107,12 +107,16 @@ export class CoreWallet extends Wallet {
     }
 
     if (this.core.sendTransaction) {
-      const transactionResponse = await this.core.sendTransaction({
+      const res = await this.core.sendTransaction({
         ...tx,
         ...(gasPrice && { gasPrice }),
       });
 
-      return new TransactionResponse(transactionResponse, this.provider!);
+      if ('skipResponse' in res) {
+        return {} as unknown as TransactionResponse;
+      } else {
+        return new TransactionResponse(res, this.provider!);
+      }
     }
 
     return super.sendTransaction({

--- a/packages/arianee-protocol-client/src/lib/utils/transactions/transactionWrapper.ts
+++ b/packages/arianee-protocol-client/src/lib/utils/transactions/transactionWrapper.ts
@@ -14,7 +14,7 @@ export type NonPayableOverrides = Omit<
   'value' | 'blockTag' | 'enableCcipRead'
 >;
 
-export const transactionWrapper = async (
+export const noWaitTransactionWrapper = async (
   arianeeProtocolClient: ArianeeProtocolClient,
   protocolName: Protocol['name'],
   actions: {
@@ -26,7 +26,7 @@ export const transactionWrapper = async (
     ) => Promise<ContractTransactionResponse>;
   },
   connectOptions?: Parameters<ArianeeProtocolClient['connect']>[1]
-): Promise<ContractTransactionReceipt> => {
+): Promise<ContractTransactionResponse> => {
   const protocol = await arianeeProtocolClient.connect(
     protocolName,
     connectOptions
@@ -58,7 +58,31 @@ export const transactionWrapper = async (
     }
   }
 
+  return tx;
+};
+
+export const transactionWrapper = async (
+  arianeeProtocolClient: ArianeeProtocolClient,
+  protocolName: Protocol['name'],
+  actions: {
+    protocolV1Action: (
+      v1: ProtocolClientV1
+    ) => Promise<ContractTransactionResponse>;
+    protocolV2Action: (
+      v2: ProtocolClientV2
+    ) => Promise<ContractTransactionResponse>;
+  },
+  connectOptions?: Parameters<ArianeeProtocolClient['connect']>[1]
+): Promise<ContractTransactionReceipt> => {
+  const tx = await noWaitTransactionWrapper(
+    arianeeProtocolClient,
+    protocolName,
+    actions,
+    connectOptions
+  );
+
   let receipt: ContractTransactionReceipt | null;
+
   try {
     receipt = await tx.wait();
   } catch (e) {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@ The Core class is a TypeScript class that provides an interface for signing mess
 
 ## Usage
 
-You can instanciante core with :
+You can instantiate core with :
 
 - Mnemonic
 - Passphrase
@@ -20,13 +20,21 @@ Core.fromPrivateKey(privateKey);
 Core.fromRandom();
 ```
 
-The returned instance will have 2 method:
+The returned instance will have 4 methods (see [TransactionLike](https://docs.ethers.org/v6/api/transaction/#TransactionLike)):
 
-- signMessage(message:string)
-- signTransaction(transaction:[TransactionLike](https://docs.ethers.org/v6/api/transaction/#TransactionLike))
-- getAddress():string
+```typescript
+signMessage(message:string)
 
-If you need to implement core with an external wallet (like metamask), you need to instantiate the class with 2 functions:
+signTransaction(transaction: TransactionLike))
+
+sendTransaction(transaction: TransactionRequest) : Promise<TransactionResponse | { skipResponse: true }>
+
+getAddress():string
+```
+
+**Note**: If you are using `sendTransaction` in an asynchronous context (e.g. adding the transaction to a queue instead of sending it directly), you **must** return `{ skipResponse: true }` instead of a `TransactionResponse` so that the `@arianee/*` packages won't try to fetch the transaction receipt.
+
+If you need to implement core with an external wallet (like metamask), you need to instantiate the class with 3 functions:
 
 - signMessage is a function that behaves like the [signMessage from ethers](https://docs.ethers.io/v6/api/signer/#Signer-signMessage)
 - signTransaction is a function that behaves like the [signTransaction from ethers](https://docs.ethers.io/v6/api/signer/#Signer-signTransaction)

--- a/packages/core/src/lib/core.ts
+++ b/packages/core/src/lib/core.ts
@@ -18,7 +18,9 @@ export default class Core {
     | undefined;
 
   public sendTransaction!:
-    | ((transaction: TransactionRequest) => Promise<TransactionResponse>)
+    | ((
+        transaction: TransactionRequest
+      ) => Promise<TransactionResponse | { skipResponse: true }>)
     | undefined;
 
   public getAddress!: () => string;

--- a/packages/creator/README.md
+++ b/packages/creator/README.md
@@ -12,7 +12,7 @@ npm install @arianee/creator @arianee/core
 
 ## Usage
 
-Instantiate a new `Creator` instance and pass the required params `core` and `creatorAddress`. \
+Instantiate a new `Creator` instance and pass the required params `core`, `creatorAddress` and `transactionStrategy`.
 
 ```typescript
 import { Creator } from '@arianee/creator';
@@ -21,6 +21,7 @@ import { Core } from '@arianee/core';
 const creator = new Creator({
   core: Core.fromRandom(),
   creatorAddress: '0x...',
+  transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
 });
 ```
 
@@ -41,6 +42,28 @@ You then need to connect to the desired protocol instance using the `connect` me
 ```
 
 Most methods of the library require a connection prior to being used. If you try to use a method without being connected, it will throw a `NotConnectedError`.
+
+## Constructor
+
+The constructor takes different parameters:
+
+```typescript
+export type TransactionStrategy = 'WAIT_TRANSACTION_RECEIPT' | 'DO_NOT_WAIT_TRANSACTION_RECEIPT';
+
+export type CreatorParams<T extends TransactionStrategy> = {
+  creatorAddress: string;
+  core: Core;
+  transactionStrategy: T;
+  fetchLike?: typeof fetch;
+  protocolDetailsResolver?: ProtocolDetailsResolver;
+};
+```
+
+- `creatorAddress`: the address that will receive the Arianee protocol rewards
+- `core`: an `@arianee/core` instance
+- `transactionStrategy`: either to wait for transaction receipt or not. **The recommended value for most users is `'WAIT_TRANSACTION_RECEIPT'`**. If `'WAIT_TRANSACTION_RECEIPT'` is passed, the `Creator` will wait for the transaction receipt, ensuring that the transaction has been successful, and methods will return a `ContractTransactionReceipt`. If `'DO_NOT_WAIT_TRANSACTION_RECEIPT'` is passed, the `Creator` will not wait for the receipt and methods will return a `ContractTransactionResponse`. This means the transaction might fail without notification. The latter is suitable for programs that utilize transaction queues and cannot wait for transaction confirmations. If the `@arianee/core` instance you are using has a custom `sendTransaction` method for queuing transactions (one that resolves to `{ skipResponse: true }`), you need to use `'DO_NOT_WAIT_TRANSACTION_RECEIPT'`.
+- `fetchLike`: this is the fetch-like function used for making HTTP requests. It can be any function that has the same signature as the `fetch` function. By default, it uses the `defaultFetchLike` of `@arianee/utils`.
+- `protocolDetailsResolver`: you can provide a custom protocol details resolver, it can be any function that has the same signature as the `protocolDetailsResolver` function of `@arianee/arianee-protocol-client`.
 
 ## Examples
 

--- a/packages/creator/src/lib/creator.spec.ts
+++ b/packages/creator/src/lib/creator.spec.ts
@@ -11,12 +11,13 @@ jest.spyOn(console, 'error').mockImplementation();
 describe('Creator', () => {
   const core = Core.fromRandom();
   const creatorAddress = `0x${'a'.repeat(40)}`;
-  let creator: Creator;
+  let creator: Creator<'WAIT_TRANSACTION_RECEIPT'>;
 
   beforeEach(() => {
     creator = new Creator({
       core,
       creatorAddress,
+      transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
     });
 
     Object.defineProperty(Creator.prototype, 'connected', {
@@ -35,6 +36,7 @@ describe('Creator', () => {
       const creator = new Creator({
         core,
         creatorAddress,
+        transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
       });
 
       expect(creator['fetchLike']).toBe(defaultFetchLike);
@@ -46,6 +48,7 @@ describe('Creator', () => {
         core,
         creatorAddress,
         fetchLike,
+        transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
       });
 
       expect(creator['fetchLike']).toBe(fetchLike);
@@ -58,6 +61,7 @@ describe('Creator', () => {
         core,
         creatorAddress,
         protocolDetailsResolver,
+        transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
       });
 
       expect(
@@ -81,6 +85,7 @@ describe('Creator', () => {
       const creator = new Creator({
         core,
         creatorAddress,
+        transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
       });
 
       await expect(creator.connect('slug')).rejects.toThrow(
@@ -101,6 +106,7 @@ describe('Creator', () => {
       const creator = new Creator({
         core,
         creatorAddress,
+        transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
       });
 
       const connected = await creator.connect('slug');

--- a/packages/creator/src/lib/events/events.spec.ts
+++ b/packages/creator/src/lib/events/events.spec.ts
@@ -18,12 +18,13 @@ jest.spyOn(console, 'error').mockImplementation();
 describe('Events', () => {
   const core = Core.fromRandom();
   const creatorAddress = `0x${'a'.repeat(40)}`;
-  let creator: Creator;
+  let creator: Creator<'WAIT_TRANSACTION_RECEIPT'>;
 
   beforeEach(() => {
     creator = new Creator({
       core,
       creatorAddress,
+      transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
     });
 
     Object.defineProperty(Creator.prototype, 'connected', {

--- a/packages/creator/src/lib/events/events.ts
+++ b/packages/creator/src/lib/events/events.ts
@@ -1,11 +1,8 @@
 import { ArianeePrivacyGatewayClient } from '@arianee/arianee-privacy-gateway-client';
-import {
-  NonPayableOverrides,
-  transactionWrapper,
-} from '@arianee/arianee-protocol-client';
+import { NonPayableOverrides } from '@arianee/arianee-protocol-client';
 import { ArianeeEventI18N } from '@arianee/common-types';
 
-import Creator from '../creator';
+import Creator, { TransactionStrategy } from '../creator';
 import { requiresConnection } from '../decorators/requiresConnection';
 import { ArianeePrivacyGatewayError } from '../errors';
 import { checkCreditsBalance } from '../helpers/checkCredits/checkCredits';
@@ -22,8 +19,8 @@ import {
   CreditType,
 } from '../types';
 
-export default class Events {
-  constructor(private creator: Creator) {}
+export default class Events<Strategy extends TransactionStrategy> {
+  constructor(private creator: Creator<Strategy>) {}
 
   @requiresConnection()
   public async createAndStoreEvent(
@@ -112,7 +109,7 @@ export default class Events {
 
     const imprint = await this.creator.utils.calculateImprint(params.content);
 
-    await transactionWrapper(
+    await this.creator.transactionWrapper(
       this.creator.arianeeProtocolClient,
       this.creator.slug!,
       {

--- a/packages/creator/src/lib/helpers/checkCredits/checkCredits.ts
+++ b/packages/creator/src/lib/helpers/checkCredits/checkCredits.ts
@@ -1,3 +1,4 @@
+import { TransactionStrategy } from '../../creator';
 import {
   InsufficientEventCreditsError,
   InsufficientMessageCreditsError,
@@ -6,8 +7,8 @@ import {
 import { CreditType } from '../../types';
 import Utils from '../../utils/utils';
 
-export const checkCreditsBalance = async (
-  utils: Utils,
+export const checkCreditsBalance = async <Strategy extends TransactionStrategy>(
+  utils: Utils<Strategy>,
   creditType: CreditType,
   minAmount = BigInt(1),
   contractAddress?: string

--- a/packages/creator/src/lib/helpers/event/checkCreateEventParameters.ts
+++ b/packages/creator/src/lib/helpers/event/checkCreateEventParameters.ts
@@ -1,9 +1,11 @@
-import Creator from '../../creator';
+import Creator, { TransactionStrategy } from '../../creator';
 import { UnavailableEventIdError } from '../../errors';
 import { CreateEventParameters, CreateEventParametersBase } from '../../types';
 
-export const checkCreateEventParameters = async (
-  creator: Creator,
+export const checkCreateEventParameters = async <
+  Strategy extends TransactionStrategy
+>(
+  creator: Creator<Strategy>,
   params: CreateEventParametersBase | CreateEventParameters
 ) => {
   if (!params.smartAssetId) throw new Error('Smart asset id required');

--- a/packages/creator/src/lib/helpers/event/getCreateEventParams.ts
+++ b/packages/creator/src/lib/helpers/event/getCreateEventParams.ts
@@ -1,8 +1,11 @@
+import { TransactionStrategy } from '../../creator';
 import { CreateEventParameters, CreateEventParametersBase } from '../../types';
 import Utils from '../../utils/utils';
 
-export const getCreateEventParams = async (
-  utils: Utils,
+export const getCreateEventParams = async <
+  Strategy extends TransactionStrategy
+>(
+  utils: Utils<Strategy>,
   params: CreateEventParametersBase | CreateEventParameters
 ) => {
   const eventId = params.eventId ?? (await utils.getAvailableEventId());

--- a/packages/creator/src/lib/helpers/identity/getCreatorIdentity.ts
+++ b/packages/creator/src/lib/helpers/identity/getCreatorIdentity.ts
@@ -2,11 +2,11 @@
 import { callWrapper } from '@arianee/arianee-protocol-client';
 import { ArianeeBrandIdentityI18N } from '@arianee/common-types';
 
-import Creator from '../../creator';
+import Creator, { TransactionStrategy } from '../../creator';
 import { MalformedIdentityError, NoIdentityError } from '../../errors';
 
-export const getCreatorIdentity = async (
-  creator: Creator
+export const getCreatorIdentity = async <Strategy extends TransactionStrategy>(
+  creator: Creator<Strategy>
 ): Promise<
   ArianeeBrandIdentityI18N & {
     rpcEndpoint: NonNullable<ArianeeBrandIdentityI18N['rpcEndpoint']>;

--- a/packages/creator/src/lib/helpers/message/checkCreateMessageParameters.ts
+++ b/packages/creator/src/lib/helpers/message/checkCreateMessageParameters.ts
@@ -1,12 +1,14 @@
-import Creator from '../../creator';
+import Creator, { TransactionStrategy } from '../../creator';
 import { UnavailableMessageIdError } from '../../errors';
 import {
   CreateMessageParameters,
   CreateMessageParametersBase,
 } from '../../types';
 
-export const checkCreateMessageParameters = async (
-  creator: Creator,
+export const checkCreateMessageParameters = async <
+  Strategy extends TransactionStrategy
+>(
+  creator: Creator<Strategy>,
   params: CreateMessageParametersBase | CreateMessageParameters
 ) => {
   if (!params.smartAssetId) throw new Error('Smart asset id required');

--- a/packages/creator/src/lib/helpers/message/getCreateMessageParams.ts
+++ b/packages/creator/src/lib/helpers/message/getCreateMessageParams.ts
@@ -1,11 +1,14 @@
+import { TransactionStrategy } from '../../creator';
 import {
   CreateMessageParameters,
   CreateMessageParametersBase,
 } from '../../types';
 import Utils from '../../utils/utils';
 
-export const getCreateMessageParams = async (
-  utils: Utils,
+export const getCreateMessageParams = async <
+  Strategy extends TransactionStrategy
+>(
+  utils: Utils<Strategy>,
   params: CreateMessageParametersBase | CreateMessageParameters
 ) => {
   const messageId = params.messageId ?? (await utils.getAvailableMessageId());

--- a/packages/creator/src/lib/helpers/smartAsset/assertSmartAssetIssuedBy.ts
+++ b/packages/creator/src/lib/helpers/smartAsset/assertSmartAssetIssuedBy.ts
@@ -1,9 +1,12 @@
 import { SmartAsset } from '@arianee/common-types';
 
+import { TransactionStrategy } from '../../creator';
 import { NotIssuerError } from '../../errors';
 import Utils from '../../utils/utils';
 
-export const assertSmartAssetIssuedBy = async (
+export const assertSmartAssetIssuedBy = async <
+  Strategy extends TransactionStrategy
+>(
   {
     smartAssetId,
     expectedIssuer,
@@ -11,7 +14,7 @@ export const assertSmartAssetIssuedBy = async (
     smartAssetId: SmartAsset['certificateId'];
     expectedIssuer: string;
   },
-  utils: Utils
+  utils: Utils<Strategy>
 ) => {
   const issuer = await utils.getSmartAssetIssuer(smartAssetId);
 

--- a/packages/creator/src/lib/helpers/smartAsset/checkCreateSmartAssetParameters.ts
+++ b/packages/creator/src/lib/helpers/smartAsset/checkCreateSmartAssetParameters.ts
@@ -1,9 +1,12 @@
+import { TransactionStrategy } from '../../creator';
 import { UnavailableSmartAssetIdError } from '../../errors';
 import { CreateSmartAssetParametersBase } from '../../types';
 import Utils from '../../utils/utils';
 
-export const checkCreateSmartAssetParameters = async (
-  utils: Utils,
+export const checkCreateSmartAssetParameters = async <
+  Strategy extends TransactionStrategy
+>(
+  utils: Utils<Strategy>,
   params: CreateSmartAssetParametersBase
 ) => {
   if (!params.smartAssetId) throw new Error('Smart asset id required');

--- a/packages/creator/src/lib/helpers/smartAsset/getCreateSmartAssetParams.ts
+++ b/packages/creator/src/lib/helpers/smartAsset/getCreateSmartAssetParams.ts
@@ -1,3 +1,4 @@
+import { TransactionStrategy } from '../../creator';
 import {
   CreateSmartAssetParameters,
   CreateSmartAssetParametersBase,
@@ -5,8 +6,10 @@ import {
 import Utils from '../../utils/utils';
 import { getTokenAccessParams } from '../getTokenAccessParams/getTokenAccessParams';
 
-export const getCreateSmartAssetParams = async (
-  utils: Utils,
+export const getCreateSmartAssetParams = async <
+  Strategy extends TransactionStrategy
+>(
+  utils: Utils<Strategy>,
   params: CreateSmartAssetParametersBase | CreateSmartAssetParameters
 ) => {
   const smartAssetId =

--- a/packages/creator/src/lib/identities/identities.spec.ts
+++ b/packages/creator/src/lib/identities/identities.spec.ts
@@ -11,12 +11,13 @@ jest.spyOn(console, 'error').mockImplementation();
 describe('Identities', () => {
   const core = Core.fromRandom();
   const creatorAddress = `0x${'a'.repeat(40)}`;
-  let creator: Creator;
+  let creator: Creator<'WAIT_TRANSACTION_RECEIPT'>;
 
   beforeEach(() => {
     creator = new Creator({
       core,
       creatorAddress,
+      transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
     });
 
     Object.defineProperty(Creator.prototype, 'connected', {

--- a/packages/creator/src/lib/messages/messages.spec.ts
+++ b/packages/creator/src/lib/messages/messages.spec.ts
@@ -18,12 +18,13 @@ jest.spyOn(console, 'error').mockImplementation();
 describe('Messages', () => {
   const core = Core.fromRandom();
   const creatorAddress = `0x${'a'.repeat(40)}`;
-  let creator: Creator;
+  let creator: Creator<'WAIT_TRANSACTION_RECEIPT'>;
 
   beforeEach(() => {
     creator = new Creator({
       core,
       creatorAddress,
+      transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
     });
 
     Object.defineProperty(Creator.prototype, 'connected', {

--- a/packages/creator/src/lib/messages/messages.ts
+++ b/packages/creator/src/lib/messages/messages.ts
@@ -1,11 +1,8 @@
 import { ArianeePrivacyGatewayClient } from '@arianee/arianee-privacy-gateway-client';
-import {
-  NonPayableOverrides,
-  transactionWrapper,
-} from '@arianee/arianee-protocol-client';
+import { NonPayableOverrides } from '@arianee/arianee-protocol-client';
 import { ArianeeMessageI18N } from '@arianee/common-types';
 
-import Creator from '../creator';
+import Creator, { TransactionStrategy } from '../creator';
 import { requiresConnection } from '../decorators/requiresConnection';
 import { ArianeePrivacyGatewayError } from '../errors';
 import { checkCreditsBalance } from '../helpers/checkCredits/checkCredits';
@@ -21,8 +18,8 @@ import {
   CreditType,
 } from '../types';
 
-export default class Messages {
-  constructor(private creator: Creator) {}
+export default class Messages<Strategy extends TransactionStrategy> {
+  constructor(private creator: Creator<Strategy>) {}
 
   @requiresConnection()
   public async createAndStoreMessage(
@@ -85,7 +82,7 @@ export default class Messages {
 
     const imprint = await this.creator.utils.calculateImprint(params.content);
 
-    await transactionWrapper(
+    await this.creator.transactionWrapper(
       this.creator.arianeeProtocolClient,
       this.creator.slug!,
       {

--- a/packages/creator/src/lib/smartAssets/smartAssets.spec.ts
+++ b/packages/creator/src/lib/smartAssets/smartAssets.spec.ts
@@ -19,12 +19,13 @@ jest.spyOn(console, 'error').mockImplementation();
 describe('SmartAssets', () => {
   const core = Core.fromRandom();
   const creatorAddress = `0x${'a'.repeat(40)}`;
-  let creator: Creator;
+  let creator: Creator<'WAIT_TRANSACTION_RECEIPT'>;
 
   beforeEach(() => {
     creator = new Creator({
       core,
       creatorAddress,
+      transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
     });
 
     Object.defineProperty(Creator.prototype, 'connected', {

--- a/packages/creator/src/lib/smartAssets/smartAssets.ts
+++ b/packages/creator/src/lib/smartAssets/smartAssets.ts
@@ -1,17 +1,18 @@
 import { ArianeePrivacyGatewayClient } from '@arianee/arianee-privacy-gateway-client';
-import {
-  NonPayableOverrides,
-  transactionWrapper,
-} from '@arianee/arianee-protocol-client';
+import { NonPayableOverrides } from '@arianee/arianee-protocol-client';
 import {
   ArianeeProductCertificateI18N,
   SmartAsset,
   TokenAccessType,
 } from '@arianee/common-types';
 import { createLink } from '@arianee/utils';
-import { ethers } from 'ethers';
+import {
+  ContractTransactionReceipt,
+  ContractTransactionResponse,
+  ethers,
+} from 'ethers';
 
-import Creator from '../creator';
+import Creator, { TransactionStrategy } from '../creator';
 import { requiresConnection } from '../decorators/requiresConnection';
 import {
   ArianeePrivacyGatewayError,
@@ -34,8 +35,8 @@ import {
   TokenAccess,
 } from '../types';
 
-export default class SmartAssets {
-  constructor(private creator: Creator) {}
+export default class SmartAssets<Strategy extends TransactionStrategy> {
+  constructor(private creator: Creator<Strategy>) {}
 
   @requiresConnection()
   public async reserveSmartAssetId(
@@ -51,7 +52,7 @@ export default class SmartAssets {
 
     const _id = id ?? (await this.creator.utils.getAvailableSmartAssetId());
 
-    return transactionWrapper(
+    return this.creator.transactionWrapper(
       this.creator.arianeeProtocolClient,
       this.creator.slug!,
       {
@@ -74,7 +75,11 @@ export default class SmartAssets {
           ),
       },
       this.creator.connectOptions
-    );
+    ) as Promise<
+      Strategy extends 'WAIT_TRANSACTION_RECEIPT'
+        ? ContractTransactionReceipt
+        : ContractTransactionResponse
+    >;
   }
 
   @requiresConnection()
@@ -87,7 +92,7 @@ export default class SmartAssets {
     if (smartAssetOwner !== this.creator.core.getAddress())
       throw new NotOwnerError('You are not the owner of this smart asset');
 
-    return transactionWrapper(
+    return this.creator.transactionWrapper(
       this.creator.arianeeProtocolClient,
       this.creator.slug!,
       {
@@ -103,7 +108,11 @@ export default class SmartAssets {
         },
       },
       this.creator.connectOptions
-    );
+    ) as Promise<
+      Strategy extends 'WAIT_TRANSACTION_RECEIPT'
+        ? ContractTransactionReceipt
+        : ContractTransactionResponse
+    >;
   }
 
   @requiresConnection()
@@ -119,7 +128,7 @@ export default class SmartAssets {
       this.creator.utils
     );
 
-    return transactionWrapper(
+    return this.creator.transactionWrapper(
       this.creator.arianeeProtocolClient,
       this.creator.slug!,
       {
@@ -130,7 +139,11 @@ export default class SmartAssets {
         },
       },
       this.creator.connectOptions
-    );
+    ) as Promise<
+      Strategy extends 'WAIT_TRANSACTION_RECEIPT'
+        ? ContractTransactionReceipt
+        : ContractTransactionResponse
+    >;
   }
 
   @requiresConnection()
@@ -187,7 +200,7 @@ export default class SmartAssets {
 
     const imprint = await this.creator.utils.calculateImprint(content);
 
-    await transactionWrapper(
+    await this.creator.transactionWrapper(
       this.creator.arianeeProtocolClient,
       this.creator.slug!,
       {
@@ -232,7 +245,7 @@ export default class SmartAssets {
 
     const { publicKey, passphrase } = getTokenAccessParams(tokenAccess);
 
-    await transactionWrapper(
+    await this.creator.transactionWrapper(
       this.creator.arianeeProtocolClient,
       this.creator.slug!,
       {
@@ -284,7 +297,7 @@ export default class SmartAssets {
 
     await getContentFromURI(uri, this.creator.fetchLike);
 
-    await transactionWrapper(
+    await this.creator.transactionWrapper(
       this.creator.arianeeProtocolClient,
       this.creator.slug!,
       {
@@ -330,7 +343,7 @@ export default class SmartAssets {
 
     const imprint = await this.creator.utils.calculateImprint(params.content);
 
-    await transactionWrapper(
+    await this.creator.transactionWrapper(
       this.creator.arianeeProtocolClient,
       this.creator.slug!,
       {

--- a/packages/creator/src/lib/utils/utils.spec.ts
+++ b/packages/creator/src/lib/utils/utils.spec.ts
@@ -14,12 +14,13 @@ describe('Creator', () => {
   );
   const publicKey = '0x655F362F23cA6B937a2418F882097Ea3B2b14Ef0';
   const creatorAddress = `0x${'a'.repeat(40)}`;
-  let creator: Creator;
+  let creator: Creator<'WAIT_TRANSACTION_RECEIPT'>;
 
   beforeEach(() => {
     creator = new Creator({
       core,
       creatorAddress,
+      transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
     });
 
     Object.defineProperty(Creator.prototype, 'connected', {
@@ -205,6 +206,7 @@ describe('Creator', () => {
       const creator = new Creator({
         core: Core.fromRandom(),
         creatorAddress: '0x' + 'a'.repeat(40),
+        transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
         fetchLike: fetch,
       });
       const imprint = await creator.utils.calculateImprint(content);
@@ -408,6 +410,7 @@ describe('Creator', () => {
         core: Core.fromRandom(),
         creatorAddress: '0x' + 'a'.repeat(40),
         fetchLike: mockedFetch as unknown as typeof fetch,
+        transactionStrategy: 'WAIT_TRANSACTION_RECEIPT',
       });
 
       Object.defineProperty(creator, 'slug', {

--- a/scripts/link.sh
+++ b/scripts/link.sh
@@ -1,0 +1,62 @@
+# A script to easily link all the SDK packages
+# Run `npm run link:all` after running `npm run build:all`
+# The script will automatically link/unlink the packages in the dist folder
+# At the end of the script, copy the `npm link ...` command and run it in your external project
+#
+# Warning: make sure that the node version you use when you run `npm run build:all` && `npm run link:all` is the same as the one you use in your external project
+
+
+PATH_TO_FOLDERS="$PWD/dist/packages"
+CONCATENATION=""
+
+generateLinkCommand() {
+  local EXCLUDE_PACKAGE="$1"
+  local LINK_COMMAND="npm link"
+  for PACKAGE in $CONCATENATION; do
+    if [ "$PACKAGE" != "$EXCLUDE_PACKAGE" ]; then
+      LINK_COMMAND="${LINK_COMMAND} ${PACKAGE}"
+    fi
+  done
+  echo "[in $EXCLUDE_PACKAGE] -> $LINK_COMMAND"
+  $LINK_COMMAND
+}
+
+
+# Iterate over each folder in the path
+for dir in "$PATH_TO_FOLDERS"/*; do
+  if [ -d "$dir" ]; then
+    cd "$dir"
+
+    # Extract package name from package.json and append it to CONCATENATION
+    PACKAGE_NAME=$(grep '"name":' package.json | sed 's/.*: "\(.*\)",/\1/')
+
+    npm unlink ${PACKAGE_NAME}
+    npm link
+
+    if [ ! -z "$PACKAGE_NAME" ]; then
+      CONCATENATION="${CONCATENATION} ${PACKAGE_NAME}"
+    fi
+  fi
+done
+
+
+
+for dir in "$PATH_TO_FOLDERS"/*; do
+  if [ -d "$dir" ]; then
+    cd "$dir"
+
+    PACKAGE_NAME=$(grep '"name":' package.json | sed 's/.*: "\(.*\)",/\1/')
+    generateLinkCommand $PACKAGE_NAME
+
+  fi
+done
+
+echo ""
+echo "✅ OK"
+echo ""
+echo "################"
+echo "Run this command in your external project"
+echo ""
+echo "npm link${CONCATENATION}"
+echo ""
+echo "################"


### PR DESCRIPTION
- Added a `transactionStrategy` param to `@arianee/creator`: if `WAIT_TRANSACTION` is passed, the methods will wait for the transaction to be validated and a `ContractTransactionReceipt` is returned. If `DO_NO_WAIT_TRANSACTION` is passed, the transaction validation won't be waited for and the methods will return `ContractTransactionResponse` with no validation guarantee.

This allows the use of the `@arianee/creator` library in the NMP that uses a transaction manager and thus make it not possible or impractical to wait for transaction validations.

- Updated `@arianee/core` to allow passing a `sendTransaction` that is not waited for (the function must return `{ skipResponse : true }` instead of `TransactionResponse`), this is equivalent to the `@arianee/arianeejs::setCustomSendTransaction`

- Updated `@arianee/arianee-protocol-client` to check the return value of `@arianee/core::sendTransaction` to check whether or not the transaction should be waited for

- Created an utility shell script `link.sh` that makes it seamless to link all the sdk libs and use them in an external project (arianeebranddatahub in my case)

Updated all the related readme to reflect the changes + recommandations & how to use