### PR TITLE
feat(wallet): switch passphrase from private to readonly

### DIFF
--- a/packages/wallet/src/lib/services/smartAsset/instances/smartAssetInstance.ts
+++ b/packages/wallet/src/lib/services/smartAsset/instances/smartAssetInstance.ts
@@ -1,13 +1,14 @@
-import { SmartAsset, Event, ChainType } from '@arianee/common-types';
-import ArianeeEventInstance from './arianeeEventInstance';
-import SmartAssetService from '../smartAsset';
+import { ChainType, Event, SmartAsset } from '@arianee/common-types';
 import { ContractTransactionReceipt } from 'ethers';
+
+import SmartAssetService from '../smartAsset';
+import ArianeeEventInstance from './arianeeEventInstance';
 
 export default class SmartAssetInstance<T extends ChainType> {
   public readonly data: SmartAsset;
   public readonly arianeeEvents: ArianeeEventInstance<T>[];
 
-  private passphrase?: string;
+  readonly passphrase?: string;
   private userAddress: string;
 
   constructor(


### PR DESCRIPTION
If you fetch a kiosk nft with a getFromLink(), you will need to access the smartAsset passphrase to be able to claim it.