### PR TITLE
Feat/wallet transaction strategy

### DIFF
--- a/apps/angular-wallet/src/app/components/wallet-messages/wallet-messages.component.ts
+++ b/apps/angular-wallet/src/app/components/wallet-messages/wallet-messages.component.ts
@@ -13,7 +13,8 @@ import { ChainType } from '@arianee/common-types';
   styleUrls: ['./wallet-messages.component.scss'],
 })
 export class WalletMessages implements OnInit {
-  public messages: MessageInstance<ChainType>[] = [];
+  public messages: MessageInstance<ChainType, 'WAIT_TRANSACTION_RECEIPT'>[] =
+    [];
   public loading = false;
 
   public eventsLog = '';

--- a/apps/angular-wallet/src/app/components/wallet-nfts/wallet-nfts.component.ts
+++ b/apps/angular-wallet/src/app/components/wallet-nfts/wallet-nfts.component.ts
@@ -14,7 +14,7 @@ import { ChainType } from '@arianee/common-types';
   styleUrls: ['./wallet-nfts.component.scss'],
 })
 export class WalletNfts implements OnInit {
-  public nfts: SmartAssetInstance<ChainType>[] = [];
+  public nfts: SmartAssetInstance<ChainType, 'WAIT_TRANSACTION_RECEIPT'>[] = [];
   public loading = false;
 
   public eventsLog = '';

--- a/apps/arianee-react-wallet/src/app/app.tsx
+++ b/apps/arianee-react-wallet/src/app/app.tsx
@@ -10,7 +10,10 @@ import WalletNfts from './components/walletNfts';
 import { getWallet } from './utils/wallet';
 
 export function App() {
-  const [wallet, setWallet] = useState<Wallet<ChainType> | null>(null);
+  const [wallet, setWallet] = useState<Wallet<
+    ChainType,
+    'WAIT_TRANSACTION_RECEIPT'
+  > | null>(null);
   const [walletApiUrl, setWalletApiUrl] = useState<string | null>(null);
   const [chainType, setChainType] = useState<ChainType>('testnet');
   const [userLanguage, setUserLanguage] = useState<Language>('en-US');

--- a/apps/arianee-react-wallet/src/app/components/arianeeEvent.tsx
+++ b/apps/arianee-react-wallet/src/app/components/arianeeEvent.tsx
@@ -4,7 +4,10 @@ import { useEffect, useState } from 'react';
 import { ChainType } from '@arianee/common-types';
 
 export interface ArianeeEventProps {
-  event: SmartAssetInstance<ChainType>['arianeeEvents'][number];
+  event: SmartAssetInstance<
+    ChainType,
+    'WAIT_TRANSACTION_RECEIPT'
+  >['arianeeEvents'][number];
   refreshNfts: () => void;
 }
 

--- a/apps/arianee-react-wallet/src/app/components/message.tsx
+++ b/apps/arianee-react-wallet/src/app/components/message.tsx
@@ -1,10 +1,10 @@
+import { ChainType } from '@arianee/common-types';
 import { MessageInstance } from '@arianee/wallet';
 import { TransactionReceipt } from 'ethers';
 import { useEffect, useState } from 'react';
-import { ChainType } from '@arianee/common-types';
 
 export interface MessageProps {
-  messageInstance: MessageInstance<ChainType>;
+  messageInstance: MessageInstance<ChainType, 'WAIT_TRANSACTION_RECEIPT'>;
   index: number;
 }
 

--- a/apps/arianee-react-wallet/src/app/components/nft.tsx
+++ b/apps/arianee-react-wallet/src/app/components/nft.tsx
@@ -1,10 +1,11 @@
+import { ChainType } from '@arianee/common-types';
 import { SmartAssetInstance } from '@arianee/wallet';
 import { useEffect, useState } from 'react';
+
 import ArianeeEvent from './arianeeEvent';
-import { ChainType } from '@arianee/common-types';
 
 export interface NftProps {
-  smartAssetInstance: SmartAssetInstance<ChainType>;
+  smartAssetInstance: SmartAssetInstance<ChainType, 'WAIT_TRANSACTION_RECEIPT'>;
   index: number;
   refreshNfts: () => void;
 }

--- a/apps/arianee-react-wallet/src/app/components/walletHeader.tsx
+++ b/apps/arianee-react-wallet/src/app/components/walletHeader.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { arianeeAccessToken } from '../utils/wallet';
 
 export interface WalletHeaderProps {
-  wallet: Wallet<ChainType>;
+  wallet: Wallet<ChainType, 'WAIT_TRANSACTION_RECEIPT'>;
   language: Language;
   setChainType: (newChainType: ChainType) => void;
   setUserLanguage: (newLanguage: Language) => void;

--- a/apps/arianee-react-wallet/src/app/components/walletIdentities.tsx
+++ b/apps/arianee-react-wallet/src/app/components/walletIdentities.tsx
@@ -11,7 +11,7 @@ import {
 import { getTime } from '../utils/misc';
 
 export interface WalletIdentitiesProps {
-  wallet: Wallet<ChainType>;
+  wallet: Wallet<ChainType, 'WAIT_TRANSACTION_RECEIPT'>;
   language: Language;
 }
 

--- a/apps/arianee-react-wallet/src/app/components/walletMessages.tsx
+++ b/apps/arianee-react-wallet/src/app/components/walletMessages.tsx
@@ -1,15 +1,16 @@
+import { ChainType, Language } from '@arianee/common-types';
 import Wallet, {
   MessageInstance,
   MessageReadEvent,
   MessageReceivedEvent,
 } from '@arianee/wallet';
 import { useEffect, useState } from 'react';
-import { ChainType, Language } from '@arianee/common-types';
+
 import { getTime } from '../utils/misc';
 import Message from './message';
 
 export interface WalletMessagesProps {
-  wallet: Wallet<ChainType>;
+  wallet: Wallet<ChainType, 'WAIT_TRANSACTION_RECEIPT'>;
   language: Language;
 }
 
@@ -17,7 +18,9 @@ export default function WalletMessages({
   wallet,
   language,
 }: WalletMessagesProps) {
-  const [messages, setMessages] = useState<MessageInstance<ChainType>[]>([]);
+  const [messages, setMessages] = useState<
+    MessageInstance<ChainType, 'WAIT_TRANSACTION_RECEIPT'>[]
+  >([]);
   const [loading, setLoading] = useState<boolean>(false);
 
   const [eventsLog, setEventsLog] = useState<string>('');

--- a/apps/arianee-react-wallet/src/app/components/walletNfts.tsx
+++ b/apps/arianee-react-wallet/src/app/components/walletNfts.tsx
@@ -1,22 +1,25 @@
+import { ChainType, Language } from '@arianee/common-types';
 import Wallet, {
   ArianeeEventReceivedEvent,
+  SmartAssetInstance,
   SmartAssetReceivedEvent,
   SmartAssetTransferedEvent,
   SmartAssetUpdatedEvent,
-  SmartAssetInstance,
 } from '@arianee/wallet';
 import { useCallback, useEffect, useState } from 'react';
-import { ChainType, Language } from '@arianee/common-types';
+
 import { getTime } from '../utils/misc';
 import Nft from './nft';
 
 export interface WalletNftsProps {
-  wallet: Wallet<ChainType>;
+  wallet: Wallet<ChainType, 'WAIT_TRANSACTION_RECEIPT'>;
   language: Language;
 }
 
 export default function WalletNfts({ wallet, language }: WalletNftsProps) {
-  const [nfts, setNfts] = useState<SmartAssetInstance<ChainType>[]>([]);
+  const [nfts, setNfts] = useState<
+    SmartAssetInstance<ChainType, 'WAIT_TRANSACTION_RECEIPT'>[]
+  >([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [brandsFilter, setBrandsFilter] = useState<string | 'all'>('all');
 

--- a/packages/arianee-access-token/package.json
+++ b/packages/arianee-access-token/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-access-token",
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/packages/arianee-api-client/package.json
+++ b/packages/arianee-api-client/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-api-client",
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/packages/arianee-privacy-gateway-client/package.json
+++ b/packages/arianee-privacy-gateway-client/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-privacy-gateway-client",
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/packages/arianee-protocol-client/package.json
+++ b/packages/arianee-protocol-client/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/arianee-protocol-client",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "commonjs"
 }

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/common-types",
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/core",
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/packages/creator/package.json
+++ b/packages/creator/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/creator",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "commonjs"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/utils",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "commonjs"
 }

--- a/packages/wallet-abstraction/package.json
+++ b/packages/wallet-abstraction/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet-abstraction",
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/packages/wallet-api-client/package-lock.json
+++ b/packages/wallet-api-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arianee/wallet-api-client",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arianee/wallet-api-client",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "node-fetch": "^2.6.7"
       }

--- a/packages/wallet-api-client/package.json
+++ b/packages/wallet-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arianee/wallet-api-client",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "dependencies": {
     "node-fetch": "^2.6.7"
   }

--- a/packages/wallet/README.md
+++ b/packages/wallet/README.md
@@ -21,6 +21,7 @@ Default values are:
 - `arianeeAccessToken`: a `ArianeeAccessToken` instance from `@arianee/arianee-access-token` using the core instance derived from passed auth
 - `arianeeAccessTokenPrefix`: an optional `string` that can be added before the arianee access token payload to sign. This is useful to let the user know what they are signing and why.
 - `storage`: a `MemoryStorage` from `@arianee/utils`
+- `transactionStrategy`: either to wait for transaction receipt or not. **The recommended value for most users is `'WAIT_TRANSACTION_RECEIPT'` (its default value)**. If `'WAIT_TRANSACTION_RECEIPT'` is passed, the `Wallet` will wait for the transaction receipt, ensuring that the transaction has been successful, and methods will return a `ContractTransactionReceipt`. If `'DO_NOT_WAIT_TRANSACTION_RECEIPT'` is passed, the `Wallet` will not wait for the receipt and methods will return a `ContractTransactionResponse`. This means the transaction might fail without notification. The latter is suitable for programs that utilize transaction queues and cannot wait for transaction confirmations. If the `@arianee/core` instance you are using has a custom `sendTransaction` method for queuing transactions (one that resolves to `{ skipResponse: true }`), you need to use `'DO_NOT_WAIT_TRANSACTION_RECEIPT'`.
 
 First, you need to import the `Wallet` class:
 

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet",
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/packages/wallet/src/lib/services/eventManager/eventManager.ts
+++ b/packages/wallet/src/lib/services/eventManager/eventManager.ts
@@ -1,17 +1,18 @@
-import { EventEmitter } from 'eventemitter3';
-import { WalletAbstraction } from '@arianee/wallet-abstraction';
-import { EventMap } from './types/events';
-import WrappedEventEmitter from './helpers/wrappedEventEmitter';
+import { ArianeeApiClient } from '@arianee/arianee-api-client';
 import {
-  UnnestedBlockchainEvent,
+  blockchainEventsName,
   BrandIdentity,
   ChainType,
   SmartAsset,
-  blockchainEventsName,
+  UnnestedBlockchainEvent,
 } from '@arianee/common-types';
-import { ArianeeApiClient } from '@arianee/arianee-api-client';
+import { WalletAbstraction } from '@arianee/wallet-abstraction';
+import { EventEmitter } from 'eventemitter3';
+
 import { checksumAddress } from '../../utils/address/address';
 import { hashCode } from '../../utils/hash';
+import WrappedEventEmitter from './helpers/wrappedEventEmitter';
+import { EventMap } from './types/events';
 
 type WrappedEventEmitters = {
   readonly [eventName in keyof EventMap]: WrappedEventEmitter<eventName>;

--- a/packages/wallet/src/lib/services/identity/identity.ts
+++ b/packages/wallet/src/lib/services/identity/identity.ts
@@ -4,7 +4,8 @@ import {
   ChainType,
 } from '@arianee/common-types';
 import { WalletAbstraction } from '@arianee/wallet-abstraction';
-import { I18NStrategy, getPreferredLanguages } from '../../utils/i18n';
+
+import { getPreferredLanguages, I18NStrategy } from '../../utils/i18n';
 import EventManager from '../eventManager/eventManager';
 
 export type IdentityInstance<T extends BrandIdentity | BrandIdentityWithOwned> =

--- a/packages/wallet/src/lib/services/message/instances/messageInstance.ts
+++ b/packages/wallet/src/lib/services/message/instances/messageInstance.ts
@@ -1,14 +1,18 @@
-import { DecentralizedMessage, ChainType } from '@arianee/common-types';
-import MessageService from '../message';
-import { ContractTransactionReceipt } from 'ethers';
+import { ChainType, DecentralizedMessage } from '@arianee/common-types';
 
-export default class MessageInstance<T extends ChainType> {
+import { TransactionStrategy } from '../../../wallet';
+import MessageService from '../message';
+
+export default class MessageInstance<
+  T extends ChainType,
+  S extends TransactionStrategy
+> {
   constructor(
-    private messageService: MessageService<T>,
+    private messageService: MessageService<T, S>,
     public readonly data: DecentralizedMessage
   ) {}
 
-  public async readMessage(): Promise<ContractTransactionReceipt> {
+  public async readMessage() {
     return this.messageService.readMessage(
       this.data.protocol.name,
       this.data.id

--- a/packages/wallet/src/lib/services/message/message.spec.ts
+++ b/packages/wallet/src/lib/services/message/message.spec.ts
@@ -2,6 +2,7 @@ import * as arianeeProtocolClientModule from '@arianee/arianee-protocol-client';
 import { Core } from '@arianee/core';
 import WalletApiClient from '@arianee/wallet-api-client';
 
+import Wallet from '../../wallet';
 import EventManager from '../eventManager/eventManager';
 import MessageService from './message';
 
@@ -23,7 +24,7 @@ const defaultI18nStrategy = {
 };
 
 describe('MessageService', () => {
-  let messageService: MessageService<'testnet'>;
+  let messageService: MessageService<'testnet', 'WAIT_TRANSACTION_RECEIPT'>;
   const walletApiClient = new WalletApiClient('testnet', Core.fromRandom());
   const core = Core.fromRandom();
   const arianeeProtocolClient =
@@ -39,6 +40,11 @@ describe('MessageService', () => {
     '0x123456',
     jest.fn()
   );
+
+  const transactionWrapperSpy = jest.fn();
+  const wallet = {
+    transactionWrapper: transactionWrapperSpy,
+  };
 
   const getReceivedMessagesSpy = jest
     .spyOn(walletApiClient, 'getReceivedMessages')
@@ -57,6 +63,7 @@ describe('MessageService', () => {
       i18nStrategy: defaultI18nStrategy,
       arianeeProtocolClient: arianeeProtocolClient,
       walletRewards: walletRewards,
+      wallet: wallet as unknown as Wallet,
     });
   });
 
@@ -144,11 +151,9 @@ describe('MessageService', () => {
 
   describe('readMessage', () => {
     it('should call the v1 contract with correct params', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({
+        mockReceipt: '0x123',
+      } as any);
 
       const waitSpy = jest.fn().mockResolvedValue({ mockReceipt: '0x123' });
       const readMessageSpy = jest.fn().mockResolvedValue({
@@ -177,11 +182,9 @@ describe('MessageService', () => {
       );
     });
     it('should call the v2 contract with correct params', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({
+        mockReceipt: '0x123',
+      } as any);
 
       const waitSpy = jest.fn().mockResolvedValue({ mockReceipt: '0x123' });
       const readMessageSpy = jest.fn().mockResolvedValue({
@@ -189,7 +192,6 @@ describe('MessageService', () => {
       });
 
       await messageService.readMessage('mockProtocol', '123');
-
       const { protocolV2Action } = transactionWrapperSpy.mock.calls[0][2];
 
       await protocolV2Action({
@@ -218,11 +220,9 @@ describe('MessageService', () => {
 
   describe('blackListAddress', () => {
     it('should call the v1 contract with correct params', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({
+        mockReceipt: '0x123',
+      } as any);
 
       const waitSpy = jest.fn().mockResolvedValue({ mockReceipt: '0x123' });
       const addBlacklistedAddressSpy = jest.fn().mockResolvedValue({
@@ -256,11 +256,9 @@ describe('MessageService', () => {
       );
     });
     it('should call the v2 contract with correct params', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({
+        mockReceipt: '0x123',
+      } as any);
 
       const waitSpy = jest.fn().mockResolvedValue({ mockReceipt: '0x123' });
       const addMsgPerTokenBlacklistSpy = jest.fn().mockResolvedValue({
@@ -302,11 +300,9 @@ describe('MessageService', () => {
 
   describe('unblackListAddress', () => {
     it('should call the v1 contract with correct params', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({
+        mockReceipt: '0x123',
+      } as any);
 
       const waitSpy = jest.fn().mockResolvedValue({ mockReceipt: '0x123' });
       const addBlacklistedAddressSpy = jest.fn().mockResolvedValue({
@@ -340,11 +336,9 @@ describe('MessageService', () => {
       );
     });
     it('should call the v2 contract with correct params', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({
+        mockReceipt: '0x123',
+      } as any);
 
       const waitSpy = jest.fn().mockResolvedValue({ mockReceipt: '0x123' });
       const addMsgPerTokenBlacklistSpy = jest.fn();

--- a/packages/wallet/src/lib/services/message/message.ts
+++ b/packages/wallet/src/lib/services/message/message.ts
@@ -1,20 +1,27 @@
 import ArianeeProtocolClient, {
   NonPayableOverrides,
 } from '@arianee/arianee-protocol-client';
-import { transactionWrapper } from '@arianee/arianee-protocol-client';
 import { ChainType, Protocol, SmartAsset } from '@arianee/common-types';
 import { DecentralizedMessage } from '@arianee/common-types';
 import { WalletAbstraction } from '@arianee/wallet-abstraction';
+import {
+  ContractTransactionReceipt,
+  ContractTransactionResponse,
+} from 'ethers';
 
 import { getPreferredLanguages, I18NStrategy } from '../../utils/i18n';
 import {
   getWalletReward,
   WalletRewards,
 } from '../../utils/walletReward/walletReward';
+import Wallet, { TransactionStrategy } from '../../wallet';
 import EventManager from '../eventManager/eventManager';
 import MessageInstance from './instances/messageInstance';
 
-export default class MessageService<T extends ChainType> {
+export default class MessageService<
+  T extends ChainType,
+  S extends TransactionStrategy
+> {
   public readonly received: EventManager<T>['messageReceived'];
   public readonly read: EventManager<T>['messageRead'];
 
@@ -23,6 +30,7 @@ export default class MessageService<T extends ChainType> {
   private i18nStrategy: I18NStrategy;
   private arianeeProtocolClient: ArianeeProtocolClient;
   private walletRewards: WalletRewards;
+  private wallet: Wallet<T, S>;
 
   constructor({
     walletAbstraction,
@@ -30,18 +38,21 @@ export default class MessageService<T extends ChainType> {
     i18nStrategy,
     arianeeProtocolClient,
     walletRewards,
+    wallet,
   }: {
     walletAbstraction: WalletAbstraction;
     eventManager: EventManager<T>;
     i18nStrategy: I18NStrategy;
     arianeeProtocolClient: ArianeeProtocolClient;
     walletRewards: WalletRewards;
+    wallet: Wallet<T, S>;
   }) {
     this.walletAbstraction = walletAbstraction;
     this.eventManager = eventManager;
     this.i18nStrategy = i18nStrategy;
     this.arianeeProtocolClient = arianeeProtocolClient;
     this.walletRewards = walletRewards;
+    this.wallet = wallet;
 
     this.received = this.eventManager.messageReceived;
     this.read = this.eventManager.messageRead;
@@ -60,7 +71,7 @@ export default class MessageService<T extends ChainType> {
     params?: {
       i18nStrategy?: I18NStrategy;
     }
-  ): Promise<MessageInstance<T>> {
+  ): Promise<MessageInstance<T, S>> {
     const { i18nStrategy } = params ?? {};
 
     const preferredLanguages = getPreferredLanguages(
@@ -80,7 +91,7 @@ export default class MessageService<T extends ChainType> {
    */
   async getReceived(params?: {
     i18nStrategy?: I18NStrategy;
-  }): Promise<MessageInstance<T>[]> {
+  }): Promise<MessageInstance<T, S>[]> {
     const { i18nStrategy } = params ?? {};
 
     const preferredLanguages = getPreferredLanguages(
@@ -103,21 +114,29 @@ export default class MessageService<T extends ChainType> {
     messageId: DecentralizedMessage['id'],
     overrides?: NonPayableOverrides
   ) {
-    return transactionWrapper(this.arianeeProtocolClient, protocolName, {
-      protocolV1Action: async (v1) => {
-        return v1.storeContract.readMessage(
-          messageId,
-          getWalletReward(protocolName, this.walletRewards),
-          overrides ?? {}
-        );
-      },
-      protocolV2Action: async (protocolV2) =>
-        protocolV2.messageHubContract.markMessageAsRead(
-          protocolV2.protocolDetails.contractAdresses.nft,
-          messageId,
-          getWalletReward(protocolName, this.walletRewards)
-        ),
-    });
+    return this.wallet.transactionWrapper(
+      this.arianeeProtocolClient,
+      protocolName,
+      {
+        protocolV1Action: async (v1) => {
+          return v1.storeContract.readMessage(
+            messageId,
+            getWalletReward(protocolName, this.walletRewards),
+            overrides ?? {}
+          );
+        },
+        protocolV2Action: async (protocolV2) =>
+          protocolV2.messageHubContract.markMessageAsRead(
+            protocolV2.protocolDetails.contractAdresses.nft,
+            messageId,
+            getWalletReward(protocolName, this.walletRewards)
+          ),
+      }
+    ) as Promise<
+      S extends 'WAIT_TRANSACTION_RECEIPT'
+        ? ContractTransactionReceipt
+        : ContractTransactionResponse
+    >;
   }
 
   private async setBlacklist(
@@ -127,31 +146,39 @@ export default class MessageService<T extends ChainType> {
     activate: boolean,
     overrides?: NonPayableOverrides
   ) {
-    return transactionWrapper(this.arianeeProtocolClient, protocolName, {
-      protocolV1Action: async (v1) => {
-        return v1.whitelistContract.addBlacklistedAddress(
-          messageSender,
-          smartAssetId,
-          activate,
-          overrides ?? {}
-        );
-      },
-      protocolV2Action: async (protocolV2) => {
-        if (activate) {
-          return protocolV2.rulesManagerContract.addMsgPerTokenBlacklist(
-            protocolV2.protocolDetails.contractAdresses.nft,
+    return this.wallet.transactionWrapper(
+      this.arianeeProtocolClient,
+      protocolName,
+      {
+        protocolV1Action: async (v1) => {
+          return v1.whitelistContract.addBlacklistedAddress(
+            messageSender,
             smartAssetId,
-            [messageSender]
+            activate,
+            overrides ?? {}
           );
-        } else {
-          return protocolV2.rulesManagerContract.removeMsgPerTokenBlacklist(
-            protocolV2.protocolDetails.contractAdresses.nft,
-            smartAssetId,
-            [messageSender]
-          );
-        }
-      },
-    });
+        },
+        protocolV2Action: async (protocolV2) => {
+          if (activate) {
+            return protocolV2.rulesManagerContract.addMsgPerTokenBlacklist(
+              protocolV2.protocolDetails.contractAdresses.nft,
+              smartAssetId,
+              [messageSender]
+            );
+          } else {
+            return protocolV2.rulesManagerContract.removeMsgPerTokenBlacklist(
+              protocolV2.protocolDetails.contractAdresses.nft,
+              smartAssetId,
+              [messageSender]
+            );
+          }
+        },
+      }
+    ) as Promise<
+      S extends 'WAIT_TRANSACTION_RECEIPT'
+        ? ContractTransactionReceipt
+        : ContractTransactionResponse
+    >;
   }
 
   public async blackListAddress(

--- a/packages/wallet/src/lib/services/smartAsset/instances/arianeeEventInstance.ts
+++ b/packages/wallet/src/lib/services/smartAsset/instances/arianeeEventInstance.ts
@@ -4,11 +4,14 @@ import {
   Event,
   Protocol,
 } from '@arianee/common-types';
-import SmartAssetService from '../smartAsset';
-import { ContractTransactionReceipt } from 'ethers';
 
-export default class ArianeeEventInstance<T extends ChainType>
-  implements Event
+import { TransactionStrategy } from '../../../wallet';
+import SmartAssetService from '../smartAsset';
+
+export default class ArianeeEventInstance<
+  T extends ChainType,
+  S extends TransactionStrategy
+> implements Event
 {
   public readonly id: string;
   public readonly certificateId: string;
@@ -21,7 +24,7 @@ export default class ArianeeEventInstance<T extends ChainType>
   public readonly protocol: Protocol;
 
   constructor(
-    private smartAssetService: SmartAssetService<T>,
+    private smartAssetService: SmartAssetService<T, S>,
     private isOwner: boolean,
     {
       id,
@@ -46,7 +49,7 @@ export default class ArianeeEventInstance<T extends ChainType>
     this.protocol = protocol;
   }
 
-  public async acceptEvent(): Promise<ContractTransactionReceipt> {
+  public async acceptEvent() {
     if (!this.isOwner)
       throw new Error(
         `User needs to be owner of the smart asset to accept the event (event: ${this.id}, smart asset: ${this.certificateId})`
@@ -55,7 +58,7 @@ export default class ArianeeEventInstance<T extends ChainType>
     return this.smartAssetService.acceptEvent(this.protocol.name, this.id);
   }
 
-  public async refuseEvent(): Promise<ContractTransactionReceipt> {
+  public async refuseEvent() {
     if (!this.isOwner)
       throw new Error(
         `User needs to be owner of the smart asset to refuse the event (event: ${this.id}, smart asset: ${this.certificateId})`

--- a/packages/wallet/src/lib/services/smartAsset/instances/smartAssetInstance.ts
+++ b/packages/wallet/src/lib/services/smartAsset/instances/smartAssetInstance.ts
@@ -1,18 +1,21 @@
 import { ChainType, Event, SmartAsset } from '@arianee/common-types';
-import { ContractTransactionReceipt } from 'ethers';
 
+import { TransactionStrategy } from '../../../wallet';
 import SmartAssetService from '../smartAsset';
 import ArianeeEventInstance from './arianeeEventInstance';
 
-export default class SmartAssetInstance<T extends ChainType> {
+export default class SmartAssetInstance<
+  T extends ChainType,
+  S extends TransactionStrategy
+> {
   public readonly data: SmartAsset;
-  public readonly arianeeEvents: ArianeeEventInstance<T>[];
+  public readonly arianeeEvents: ArianeeEventInstance<T, S>[];
 
   readonly passphrase?: string;
   private userAddress: string;
 
   constructor(
-    private smartAssetService: SmartAssetService<T>,
+    private smartAssetService: SmartAssetService<T, S>,
     params: { data: SmartAsset; arianeeEvents: Event[]; userAddress: string },
     opts?: { passphrase?: string }
   ) {
@@ -41,7 +44,7 @@ export default class SmartAssetInstance<T extends ChainType> {
     return this.data.owner?.toLowerCase() === this.userAddress.toLowerCase();
   }
 
-  public async claim(receiver?: string): Promise<ContractTransactionReceipt> {
+  public async claim(receiver?: string) {
     if (this.isOwner)
       throw new Error('User is already owner of the smart asset');
 

--- a/packages/wallet/src/lib/services/smartAsset/smartAsset.spec.ts
+++ b/packages/wallet/src/lib/services/smartAsset/smartAsset.spec.ts
@@ -3,6 +3,7 @@ import * as arianeeProtocolClientModule from '@arianee/arianee-protocol-client';
 import { Core } from '@arianee/core';
 import WalletApiClient from '@arianee/wallet-api-client';
 
+import Wallet from '../../wallet';
 import EventManager from '../eventManager/eventManager';
 import SmartAssetInstance from './instances/smartAssetInstance';
 import SmartAssetService from './smartAsset';
@@ -34,7 +35,10 @@ const defaultI18nStrategy = {
 };
 
 describe('SmartAssetService', () => {
-  let smartAssetService: SmartAssetService<'testnet'>;
+  let smartAssetService: SmartAssetService<
+    'testnet',
+    'WAIT_TRANSACTION_RECEIPT'
+  >;
   const core = Core.fromRandom();
   const walletApiClient = new WalletApiClient('testnet', core);
   const arianeeAccessToken = new ArianeeAccessToken(core);
@@ -51,6 +55,11 @@ describe('SmartAssetService', () => {
     '0x123456',
     jest.fn()
   );
+
+  const transactionWrapperSpy = jest.fn();
+  const wallet = {
+    transactionWrapper: transactionWrapperSpy,
+  };
 
   const getSmartAssetSpy = jest
     .spyOn(walletApiClient, 'getSmartAsset')
@@ -75,6 +84,7 @@ describe('SmartAssetService', () => {
       arianeeProtocolClient: arianeeProtocolClient,
       walletRewards: walletRewards,
       core: core,
+      wallet: wallet as unknown as Wallet,
     });
   });
 
@@ -291,6 +301,7 @@ describe('SmartAssetService', () => {
         arianeeProtocolClient: arianeeProtocolClient,
         walletRewards: walletRewards,
         core: core,
+        wallet: wallet as unknown as Wallet,
       });
 
       await expect(
@@ -325,13 +336,12 @@ describe('SmartAssetService', () => {
         core: Core.fromPrivateKey(
           '0xe5ca26599b7210485f8a4a4d1d1c1ba89752ca7b9be2f566665e730f952552e0'
         ),
+        wallet: wallet as unknown as Wallet,
       });
 
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({
+        mockReceipt: '0x123',
+      } as any);
 
       await service.claim('testnet', '86208174', 'gx2mhc408880', {
         overrides: {
@@ -383,17 +393,14 @@ describe('SmartAssetService', () => {
         core: Core.fromPrivateKey(
           '0xe5ca26599b7210485f8a4a4d1d1c1ba89752ca7b9be2f566665e730f952552e0'
         ),
+        wallet: wallet as unknown as Wallet,
       });
 
       const getSpy = jest
         .spyOn(service, 'get')
         .mockResolvedValue({ data: { issuer: '0xissuer' } } as any);
 
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({ mockReceipt: '0x123' } as any);
 
       await service.claim('testnet', '86208174', 'gx2mhc408880', {
         overrides: {
@@ -440,11 +447,7 @@ describe('SmartAssetService', () => {
 
   describe('acceptEvent', () => {
     it('should call transactionWrapper with correct params (v2)', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({ mockReceipt: '0x123' } as any);
 
       const acceptEventSpy = jest.fn();
 
@@ -477,11 +480,7 @@ describe('SmartAssetService', () => {
       );
     });
     it('should call transactionWrapper with correct params (v1)', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({ mockReceipt: '0x123' } as any);
 
       const acceptEventSpy = jest.fn();
 
@@ -514,11 +513,7 @@ describe('SmartAssetService', () => {
 
   describe('refuseEvent', () => {
     it('should call transactionWrapper with correct params', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({ mockReceipt: '0x123' } as any);
 
       const refuseEventSpy = jest.fn();
 
@@ -548,11 +543,7 @@ describe('SmartAssetService', () => {
       );
     });
     it('should call transactionWrapper with correct params (V2)', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({ mockReceipt: '0x123' } as any);
 
       const refuseEventSpy = jest.fn();
 
@@ -601,11 +592,9 @@ describe('SmartAssetService', () => {
     ])(
       'should call transactionWrapper with correct params and return the link (protocol v1)',
       async ({ linkType, expectedAccessType, expectedLink }) => {
-        const transactionWrapperSpy = jest
-          .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-          .mockResolvedValue({
-            mockReceipt: '0x123',
-          } as any);
+        transactionWrapperSpy.mockResolvedValue({
+          mockReceipt: '0x123',
+        } as any);
 
         const addTokenAccessSpy = jest.fn();
 
@@ -666,11 +655,9 @@ describe('SmartAssetService', () => {
     ])(
       'should call transactionWrapper with correct params and return the link (protocol v2)',
       async ({ linkType, expectedAccessType, expectedLink }) => {
-        const transactionWrapperSpy = jest
-          .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-          .mockResolvedValue({
-            mockReceipt: '0x123',
-          } as any);
+        transactionWrapperSpy.mockResolvedValue({
+          mockReceipt: '0x123',
+        } as any);
 
         const setTokenKey = jest.fn();
 
@@ -723,11 +710,7 @@ describe('SmartAssetService', () => {
 
   describe('transfer', () => {
     it('should call transactionWrapper with correct params (protocol v1)', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({ mockReceipt: '0x123' } as any);
 
       const transferFromSpy = jest.fn();
 
@@ -763,11 +746,7 @@ describe('SmartAssetService', () => {
     });
 
     it('should call transactionWrapper with correct params (protocol v2)', async () => {
-      const transactionWrapperSpy = jest
-        .spyOn(arianeeProtocolClientModule, 'transactionWrapper')
-        .mockResolvedValue({
-          mockReceipt: '0x123',
-        } as any);
+      transactionWrapperSpy.mockResolvedValue({ mockReceipt: '0x123' } as any);
 
       const transferFromSpy = jest.fn();
 

--- a/packages/wallet/src/lib/wallet.spec.ts
+++ b/packages/wallet/src/lib/wallet.spec.ts
@@ -1,16 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import Wallet from './wallet';
-import Core from '@arianee/core';
-import WalletApiClient from '@arianee/wallet-api-client';
-import IdentityService from './services/identity/identity';
-import SmartAssetService from './services/smartAsset/smartAsset';
-import MessageService from './services/message/message';
-import EventManager from './services/eventManager/eventManager';
 import { ArianeeAccessToken } from '@arianee/arianee-access-token';
 import ArianeeProtocolClient from '@arianee/arianee-protocol-client';
+import Core from '@arianee/core';
 import { defaultFetchLike } from '@arianee/utils';
 import { MemoryStorage } from '@arianee/utils';
+import WalletApiClient from '@arianee/wallet-api-client';
+
+import EventManager from './services/eventManager/eventManager';
+import IdentityService from './services/identity/identity';
+import MessageService from './services/message/message';
+import SmartAssetService from './services/smartAsset/smartAsset';
+import Wallet from './wallet';
 
 jest.mock('@arianee/core');
 jest.mock('@arianee/wallet-api-client');
@@ -206,6 +207,7 @@ describe('Wallet', () => {
         i18nStrategy: 'raw',
         arianeeProtocolClient: expect.any(ArianeeProtocolClient),
         walletRewards: wallet['walletRewards'],
+        wallet,
       });
     });
 
@@ -222,6 +224,7 @@ describe('Wallet', () => {
         arianeeProtocolClient: expect.any(ArianeeProtocolClient),
         walletRewards: wallet['walletRewards'],
         core: wallet['core'],
+        wallet,
       });
     });
 


### PR DESCRIPTION
Adds a `transactionStrategy` param to the Wallet lib constructor (just like we did with Creator expect it is optional here, meaning there is little to no change (except maybe some typing) for current users of the lib)