### PR TITLE
feat(creator): fallback to ownerOf identity if issuerOf is zero address

### DIFF
--- a/packages/arianee-protocol-client/src/lib/utils/calls/callWrapper.ts
+++ b/packages/arianee-protocol-client/src/lib/utils/calls/callWrapper.ts
@@ -31,14 +31,20 @@ export const callWrapper = async <T>(
       return await actions.protocolV1Action(protocol);
     } catch (e) {
       console.error(e);
-      throw new Error('Error while executing the protocol v1 action');
+      const message = e instanceof Error ? e.message : '';
+      throw new Error(
+        'Error while executing the protocol v1 action  ' + message
+      );
     }
   } else {
     try {
       return await actions.protocolV2Action(protocol);
     } catch (e) {
       console.error(e);
-      throw new Error('Error while executing the protocol v2 action');
+      const message = e instanceof Error ? e.message : '';
+      throw new Error(
+        'Error while executing the protocol v2 action ' + message
+      );
     }
   }
 };

--- a/packages/arianee-protocol-client/src/lib/utils/transactions/transactionWrapper.ts
+++ b/packages/arianee-protocol-client/src/lib/utils/transactions/transactionWrapper.ts
@@ -47,14 +47,20 @@ export const noWaitTransactionWrapper = async (
       tx = await actions.protocolV1Action(protocol);
     } catch (e) {
       console.error(e);
-      throw new Error('Error while executing the protocol v1 action');
+      const message = e instanceof Error ? e.message : '';
+      throw new Error(
+        'Error while executing the protocol v1 action ' + message
+      );
     }
   } else {
     try {
       tx = await actions.protocolV2Action(protocol);
     } catch (e) {
       console.error(e);
-      throw new Error('Error while executing the protocol v2 action');
+      const message = e instanceof Error ? e.message : '';
+      throw new Error(
+        'Error while executing the protocol v2 action ' + message
+      );
     }
   }
 


### PR DESCRIPTION
example with a simple queue:
```typescript

  const core = Core.fromPrivateKey(
    '0x....'
  );


  const txs: any = [];

  core.sendTransaction = async (tx) => {
    txs.push(tx);
    console.log('added tx');
    return { skipResponse: true };
  };

  const creator = new Creator({
    core: core,
    creatorAddress: '0x6C0084Bb281dcE6B0f0cc86191086531A50dDf04',
    transactionStrategy: 'DO_NOT_WAIT_TRANSACTION_RECEIPT',
  });

  await creator.connect('testnet');

  await creator.smartAssets.createAndStoreSmartAsset({
    content: {
      $schema:
        'https://cert.arianee.org/version5/ArianeeProductCertificate-i18n.json',
      name: 'test reserved',
    },
    smartAssetId: 2722722222222,
  });

  await creator.events.createAndStoreEvent({
    content: {
      $schema: 'https://cert.arianee.org/version1/ArianeeEvent-i18n.json',
      title: 'test on reserved',
    },
    smartAssetId: 2722722222222,
    useSmartAssetIssuerPrivacyGateway: true,
  });

  await new Promise((resolve) => setTimeout(resolve, 10000));



  for (const tx of txs) {
    console.log('sending...');
    const response = await new ethers.Wallet(
      '0x...'
    )
      .connect(creator.connectedProtocolClient.provider as any)
      .sendTransaction(tx);

    await response.wait();

    console.log('sent');
  }
```

-> https://bdh-maxime.staging.arianee.com/certificate/read/2722722222222