### PR TITLE
feat(creator): trim passphrase

### DIFF
--- a/packages/creator/src/lib/helpers/getTokenAccessParams/getTokenAccessParams.spec.ts
+++ b/packages/creator/src/lib/helpers/getTokenAccessParams/getTokenAccessParams.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { TokenAccess } from '../../types';
 import { getTokenAccessParams } from './getTokenAccessParams';
 
@@ -24,5 +25,28 @@ describe('getTokenAccessParams', () => {
     expect(() =>
       getTokenAccessParams({ invalid: 'property' } as unknown as TokenAccess)
     ).toThrow('Invalid token access');
+  });
+  describe('getTokenAccessParams with trimming functionality', () => {
+    it('should trim leading spaces or tabs from the passphrase and return the correct address', () => {
+      // Assuming 'generateRandomPassphrase' and 'Core.fromPassPhrase' are mocked or their behavior is predictable in the test environment
+      // Example passphrase with leading spaces and tabs
+      const passphraseWithSpaces = '    cfbsfms598wr       '; // Leading spaces
+      const passphraseWithTabs = '\t\tcfbsfms598wr'; // Leading tabs
+
+      const paramsWithSpaces = getTokenAccessParams({
+        fromPassphrase: passphraseWithSpaces,
+      });
+      const paramsWithTabs = getTokenAccessParams({
+        fromPassphrase: passphraseWithTabs,
+      });
+
+      // Assuming '0x0f1C82cC304A3ade1e38855410D5cdF3CFB024Ad' is the expected address for the trimmed passphrase 'cfbsfms598wr'
+      const expectedAddress = '0x0f1C82cC304A3ade1e38855410D5cdF3CFB024Ad';
+
+      expect(paramsWithSpaces.passphrase).toBe('cfbsfms598wr');
+      expect(paramsWithSpaces.publicKey).toBe(expectedAddress);
+      expect(paramsWithTabs.passphrase).toBe('cfbsfms598wr');
+      expect(paramsWithTabs.publicKey).toBe(expectedAddress);
+    });
   });
 });

--- a/packages/creator/src/lib/helpers/getTokenAccessParams/getTokenAccessParams.ts
+++ b/packages/creator/src/lib/helpers/getTokenAccessParams/getTokenAccessParams.ts
@@ -18,7 +18,7 @@ export const getTokenAccessParams = (
   } else if ('address' in tokenAccess) {
     publicKey = tokenAccess.address;
   } else if ('fromPassphrase' in tokenAccess) {
-    passphrase = tokenAccess.fromPassphrase;
+    passphrase = tokenAccess.fromPassphrase.trim();
     const wallet = Core.fromPassPhrase(passphrase);
     publicKey = wallet.getAddress();
   } else {


### PR DESCRIPTION
https://linear.app/arianee/issue/ARI-613/the-forge-avoid-spaces-and-tabulation-in-link-when-scanning-qr-code