### PR TITLE
chore: bump to 1.45.0

### DIFF
--- a/packages/arianee-access-token/package.json
+++ b/packages/arianee-access-token/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-access-token",
-  "version": "1.44.0"
+  "version": "1.45.0"
 }

--- a/packages/arianee-api-client/package.json
+++ b/packages/arianee-api-client/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-api-client",
-  "version": "1.44.0"
+  "version": "1.45.0"
 }

--- a/packages/arianee-privacy-gateway-client/package.json
+++ b/packages/arianee-privacy-gateway-client/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-privacy-gateway-client",
-  "version": "1.44.0"
+  "version": "1.45.0"
 }

--- a/packages/arianee-protocol-client/package.json
+++ b/packages/arianee-protocol-client/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/arianee-protocol-client",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "commonjs"
 }

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/common-types",
-  "version": "1.44.0"
+  "version": "1.45.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/core",
-  "version": "1.44.0"
+  "version": "1.45.0"
 }

--- a/packages/creator/package.json
+++ b/packages/creator/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/creator",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "commonjs"
 }

--- a/packages/permit721-sdk/package-lock.json
+++ b/packages/permit721-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arianee/permit721-sdk",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arianee/permit721-sdk",
-      "version": "1.44.0",
+      "version": "1.45.0",
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",

--- a/packages/permit721-sdk/package.json
+++ b/packages/permit721-sdk/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/permit721-sdk",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "commonjs"
 }

--- a/packages/service-provider/package.json
+++ b/packages/service-provider/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/service-provider",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "commonjs"
 }

--- a/packages/token-provider/package.json
+++ b/packages/token-provider/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/token-provider",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "commonjs"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/utils",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "commonjs"
 }

--- a/packages/wallet-abstraction/package.json
+++ b/packages/wallet-abstraction/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet-abstraction",
-  "version": "1.44.0"
+  "version": "1.45.0"
 }

--- a/packages/wallet-api-client/package.json
+++ b/packages/wallet-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arianee/wallet-api-client",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "dependencies": {
     "node-fetch": "^2.6.7"
   }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet",
-  "version": "1.44.0"
+  "version": "1.45.0"
 }


### PR DESCRIPTION
Bump to 1.45.0 to publish changes around authenticity computation error handling.