### PR TITLE
fix: use or instead of nullish coalescing

### DIFF
--- a/packages/arianee-access-token/package.json
+++ b/packages/arianee-access-token/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-access-token",
-  "version": "1.45.0"
+  "version": "1.46.0"
 }

--- a/packages/arianee-api-client/package.json
+++ b/packages/arianee-api-client/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-api-client",
-  "version": "1.45.0"
+  "version": "1.46.0"
 }

--- a/packages/arianee-privacy-gateway-client/package.json
+++ b/packages/arianee-privacy-gateway-client/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/arianee-privacy-gateway-client",
-  "version": "1.45.0"
+  "version": "1.46.0"
 }

--- a/packages/arianee-protocol-client/package.json
+++ b/packages/arianee-protocol-client/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/arianee-protocol-client",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "type": "commonjs"
 }

--- a/packages/arianee-protocol-client/src/lib/v1/protocolClientV1.ts
+++ b/packages/arianee-protocol-client/src/lib/v1/protocolClientV1.ts
@@ -116,7 +116,7 @@ export default class ProtocolClientV1 extends ProtocolClientBase<ProtocolDetails
     );
 
     this.userActionContract = ethers6.ArianeeUserAction__factory.connect(
-      this.protocolDetails.contractAdresses.userAction ??
+      this.protocolDetails.contractAdresses.userAction ||
         '0x0000000000000000000000000000000000000000',
       this.signer
     );

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/common-types",
-  "version": "1.45.0"
+  "version": "1.46.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/core",
-  "version": "1.45.0"
+  "version": "1.46.0"
 }

--- a/packages/creator/package.json
+++ b/packages/creator/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/creator",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "type": "commonjs"
 }

--- a/packages/permit721-sdk/package-lock.json
+++ b/packages/permit721-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arianee/permit721-sdk",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arianee/permit721-sdk",
-      "version": "1.45.0",
+      "version": "1.46.0",
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",

--- a/packages/permit721-sdk/package.json
+++ b/packages/permit721-sdk/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/permit721-sdk",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "type": "commonjs"
 }

--- a/packages/service-provider/package.json
+++ b/packages/service-provider/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/service-provider",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "type": "commonjs"
 }

--- a/packages/token-provider/package.json
+++ b/packages/token-provider/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/token-provider",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "type": "commonjs"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@arianee/utils",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "type": "commonjs"
 }

--- a/packages/wallet-abstraction/package.json
+++ b/packages/wallet-abstraction/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet-abstraction",
-  "version": "1.45.0"
+  "version": "1.46.0"
 }

--- a/packages/wallet-api-client/package.json
+++ b/packages/wallet-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arianee/wallet-api-client",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "dependencies": {
     "node-fetch": "^2.6.7"
   }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@arianee/wallet",
-  "version": "1.45.0"
+  "version": "1.46.0"
 }


### PR DESCRIPTION
Because sometimes the address are set as an empty string instead of not being defined, the nullish coalescing does not work in this case.

see https://cert.arianee.org/contractAddresses/arianeeSupernet.json with an empty string for `userAction`:
```json

{
"contractAdresses": {
"aria": "0x0000000000000000000000000000000000001010",
"creditHistory": "0x120AD58C24f5C58A4E3cB07F4546F29429e0458d",
"eventArianee": "0xD64bfed4255519711f9B26F0434555b6cC9556C1",
"identity": "0x381b9f7911119a41cf2b54047c0cD39d4D221fA3",
"smartAsset": "0x8a15FB08505da784076fc82a4e66c3C7FFABC148",
"staking": "",
"store": "0x84afB313581F91b27aFBf384DE0bE6D0fe3d8821",
"whitelist": "0x067629132c05a30DdB26608a5a4E1c3c320AD4B2",
"lost": "0x4c7Cdb2328Fd6E4Ed8C0dfA03ee0D519b4CED1C5",
"message": "0xE5Eb52fB5E85D8C388a59Ab9931B886C9BF22b8D",
"userAction": "",
"updateSmartAssets": "0x9224cBd69d1706Cce792641FF9D54c78799FCD59"
},
"httpProvider": "https://polygonsupernet.arianee.net/",
"gasStation": "https://gasstation.arianee.com/11891",
"chainId": 11891,
"protocolVersion": "1.5",
"soulbound": false
}

```


https://stackoverflow.com/questions/61480993/when-should-i-use-nullish-coalescing-vs-logical-or