### PR TITLE
feat: add support for ENS/domain issued AAT

### DIFF
--- a/apps/arianee-sdk-example/src/arianee-access-token/example.ts
+++ b/apps/arianee-sdk-example/src/arianee-access-token/example.ts
@@ -1,0 +1,33 @@
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
+
+export const example = async () => {
+  console.time('aatAddress');
+  console.log(
+    'Verifying validity of AAT issued by an eth address (0xf77e196a1ecfdafa444b7aef0967f973aae0e712)'
+  );
+  console.log(
+    'JWT content',
+    atob(
+      'eyJpc3MiOiIweGY3N0UxOTZBMUVDZmRBRkE0NDRCN0FlZjA5NjdGOTczYUFlMEU3MTIiLCJzdWIiOiJ3YWxsZXQiLCJleHAiOjIyMDUzMjQ3MjQsImlhdCI6MTczMjI4NDcyM30='
+    )
+  );
+  const valid1 = await ArianeeAccessToken.isArianeeAccessTokenValid(
+    'eyJ0eXAiOiJKV1QiLCJhbGciOiJzZWNwMjU2azEifQ==.eyJpc3MiOiIweGY3N0UxOTZBMUVDZmRBRkE0NDRCN0FlZjA5NjdGOTczYUFlMEU3MTIiLCJzdWIiOiJ3YWxsZXQiLCJleHAiOjIyMDUzMjQ3MjQsImlhdCI6MTczMjI4NDcyM30=.0x4a527c4b27231291e38e65c549f3a978b56f3b3d7d66118cf6332dc30360ccb66a3d75c679480d23131467e90ea8260b9a014f4f4f2a13226332eac698e1d12b1c'
+  );
+  console.log('valid', valid1);
+  console.timeEnd('aatAddress');
+  /*
+  console.time('aatDomain');
+  console.log('Verifying validity of AAT issued by arianee.com');
+  console.log(
+    'JWT content',
+    atob(
+      'eyJpc3MiOiJhcmlhbmVlLmNvbSIsInN1YiI6IndhbGxldCIsImV4cCI6MjIwNTEzOTUyOSwiaWF0IjoxNzMyMDk5NTI5fQ=='
+    )
+  );
+
+  console.log('wait...');
+  const valid2 = await ArianeeAccessToken.isArianeeAccessTokenValid('redacted');
+  console.log('valid', valid2);
+  console.timeEnd('aatDomain');*/
+};

--- a/apps/arianee-sdk-example/src/main.ts
+++ b/apps/arianee-sdk-example/src/main.ts
@@ -6,7 +6,8 @@
 // import protocolClient from './arianee-protocol-client';
 // import protocolClientV2 from './arianee-protocol-client/protocolClientV2';
 // import createAndStore from './creator/createAndStore';
-import privacyMode from './creator/privacy';
+// import privacyMode from './creator/privacy';
+import { example as arianeeAccessTokenExample } from './arianee-access-token/example';
 
 (async () => {
   // console.log('Uncomment the code you want to run');
@@ -21,5 +22,6 @@ import privacyMode from './creator/privacy';
   // await protocolClient();
   // await createAndStore();
   // await protocolClientV2();
-  await privacyMode();
+  // await privacyMode();
+  await arianeeAccessTokenExample();
 })();

--- a/apps/poc-sst/src/app/components/SmartAssetFromSST.tsx
+++ b/apps/poc-sst/src/app/components/SmartAssetFromSST.tsx
@@ -37,8 +37,9 @@ function SmartAssetFromSST({
           return;
         }
 
-        const { network, subId: tokenId } =
-          ArianeeAccessToken.decodeJwt(sst).payload;
+        const { network, subId: tokenId } = (
+          await ArianeeAccessToken.decodeJwt(sst)
+        ).payload;
         const _smartAsset = await serviceProvider.getSmartAssetFromSST({ sst });
 
         if (isCurrent) {

--- a/packages/service-provider/src/lib/service-provider.spec.ts
+++ b/packages/service-provider/src/lib/service-provider.spec.ts
@@ -115,7 +115,7 @@ describe('ServiceProvider', () => {
       sst: VALID_SST,
     });
 
-    const parsedSST = ServiceProvider.parseSST(VALID_SST);
+    const parsedSST = await ServiceProvider.parseSST(VALID_SST);
 
     expect(mockSmartAssetService.get).toHaveBeenCalledWith(
       parsedSST.payload.network,

--- a/packages/service-provider/src/lib/service-provider.ts
+++ b/packages/service-provider/src/lib/service-provider.ts
@@ -99,7 +99,7 @@ export class ServiceProvider {
        * If the SST was generated using the @arianee/token-provider, the SST expiration will be the same as the AAT one.
        * We do this to return a more accurate error message.
        */
-      const isValidAAT = ArianeeAccessToken.isArianeeAccessTokenValid(
+      const isValidAAT = await ArianeeAccessToken.isArianeeAccessTokenValid(
         sst,
         true
       );
@@ -107,7 +107,7 @@ export class ServiceProvider {
         throw new Error('SST is not a valid AAT');
       }
 
-      const parsedSST = ServiceProvider.parseSST(sst);
+      const parsedSST = await ServiceProvider.parseSST(sst);
       // Some deeps checks on the SST, guess would be useful for brands debugging
       if (!parsedSST || !parsedSST.payload) {
         throw new Error('Could not parse SST');
@@ -306,12 +306,12 @@ export class ServiceProvider {
     );
   }
 
-  public static parseSST(sst: string): {
+  public static async parseSST(sst: string): Promise<{
     header: JwtHeaderInterface;
     payload: SmartAssetSharingTokenPayload;
     signature: string;
-  } {
-    const parsedSST = ArianeeAccessToken.decodeJwt(sst, true);
+  }> {
+    const parsedSST = await ArianeeAccessToken.decodeJwt(sst, true);
     return {
       header: parsedSST.header,
       payload: parsedSST.payload as SmartAssetSharingTokenPayload,

--- a/packages/token-provider/src/lib/specs/generateSST.spec.ts
+++ b/packages/token-provider/src/lib/specs/generateSST.spec.ts
@@ -41,7 +41,7 @@ describe('generateSST', () => {
       nonce: 123456789,
     });
 
-    const payload = ArianeeAccessToken.decodeJwt(sst)
+    const payload = (await ArianeeAccessToken.decodeJwt(sst))
       .payload as unknown as Required<SmartAssetSharingTokenPayload>;
 
     expect(payload.iss).toEqual('0xD75f91b003D53ACf804049ead52661a28868bcCE');

--- a/packages/wallet-api-client/src/lib/walletApiClient.ts
+++ b/packages/wallet-api-client/src/lib/walletApiClient.ts
@@ -122,7 +122,7 @@ export default class WalletApiClient<T extends ChainType>
   ): Promise<SmartAsset> {
     const { preferredLanguages } = params || {};
 
-    const { payload } = ArianeeAccessToken.decodeJwt(arianeeAccessToken);
+    const { payload } = await ArianeeAccessToken.decodeJwt(arianeeAccessToken);
 
     if (payload?.sub !== 'certificate') {
       throw new Error(`Arianee Access Token should be certificate scoped`);
@@ -208,7 +208,7 @@ export default class WalletApiClient<T extends ChainType>
   ): Promise<Event[]> {
     const { preferredLanguages } = params || {};
 
-    const { payload } = ArianeeAccessToken.decodeJwt(arianeeAccessToken);
+    const { payload } = await ArianeeAccessToken.decodeJwt(arianeeAccessToken);
 
     if (payload?.sub !== 'certificate') {
       throw new Error(`Arianee Access Token should be certificate scoped`);


### PR DESCRIPTION
Note: there is a breaking change (the `ArianeeAccessToken.isArianeeAccessTokenValid` is now asynchronous), this means this will requires changes in apps where the lib is used (NMP & dapp)

