### PR TITLE
fix(utils): append child externalContents to parent ones in mergeSmartAssetAndParentSmartAsset (ARI-3292)

### DIFF
--- a/packages/utils/src/lib/mergeSmartAssetAndParentSmartAsset/mergeSmartAssetAndParentSmartAsset.spec.ts
+++ b/packages/utils/src/lib/mergeSmartAssetAndParentSmartAsset/mergeSmartAssetAndParentSmartAsset.spec.ts
@@ -1,0 +1,109 @@
+import { ArianeeProductCertificateI18N } from '@arianee/common-types';
+
+import { mergeSmartAssetAndParentSmartAsset } from './mergeSmartAssetAndParentSmartAsset';
+
+const parentNotice = {
+  type: 'website',
+  title: 'Notice',
+  url: 'https://example.com/notice',
+};
+const childLink = {
+  type: 'website',
+  title: 'Child link',
+  url: 'https://example.com/child',
+};
+
+describe('mergeSmartAssetAndParentSmartAsset', () => {
+  it('should let the child override the parent scalar properties', () => {
+    const result = mergeSmartAssetAndParentSmartAsset([
+      { name: 'parent name', description: 'parent description' },
+      { name: 'child name' },
+    ] as ArianeeProductCertificateI18N[]);
+
+    expect(result).toEqual({
+      name: 'child name',
+      description: 'parent description',
+    });
+  });
+
+  it('should concatenate child externalContents after the parent ones instead of overriding them (ARI-3292)', () => {
+    const result = mergeSmartAssetAndParentSmartAsset([
+      { name: 'parent name', externalContents: [parentNotice] },
+      { name: 'child name', externalContents: [childLink] },
+    ] as unknown as ArianeeProductCertificateI18N[]);
+
+    expect(result.name).toEqual('child name');
+    expect(result.externalContents).toEqual([parentNotice, childLink]);
+  });
+
+  it('should keep the parent externalContents when the child has none', () => {
+    const result = mergeSmartAssetAndParentSmartAsset([
+      { externalContents: [parentNotice] },
+      { name: 'child name' },
+    ] as unknown as ArianeeProductCertificateI18N[]);
+
+    expect(result.externalContents).toEqual([parentNotice]);
+  });
+
+  it('should remove externalContents duplicated between parent and child', () => {
+    const result = mergeSmartAssetAndParentSmartAsset([
+      { externalContents: [parentNotice] },
+      { externalContents: [{ ...parentNotice }, childLink] },
+    ] as unknown as ArianeeProductCertificateI18N[]);
+
+    expect(result.externalContents).toEqual([parentNotice, childLink]);
+  });
+
+  it('should accumulate externalContents across several parent levels', () => {
+    const grandParentNotice = {
+      type: 'website',
+      title: 'Grand parent',
+      url: 'https://example.com/grand-parent',
+    };
+
+    const result = mergeSmartAssetAndParentSmartAsset([
+      { externalContents: [grandParentNotice] },
+      { externalContents: [parentNotice] },
+      { externalContents: [childLink] },
+    ] as unknown as ArianeeProductCertificateI18N[]);
+
+    expect(result.externalContents).toEqual([
+      grandParentNotice,
+      parentNotice,
+      childLink,
+    ]);
+  });
+
+  it('should concatenate i18n externalContents by language and keep parent-only languages (ARI-3292)', () => {
+    const parentNoticeEn = {
+      type: 'website',
+      title: 'Notice EN',
+      url: 'https://example.com/notice-en',
+    };
+    const parentNoticeFr = {
+      type: 'website',
+      title: 'Notice FR',
+      url: 'https://example.com/notice-fr',
+    };
+    const childLinkEn = {
+      type: 'website',
+      title: 'Child link EN',
+      url: 'https://example.com/child-en',
+    };
+
+    const result = mergeSmartAssetAndParentSmartAsset([
+      {
+        i18n: [
+          { language: 'fr-FR', externalContents: [parentNoticeFr] },
+          { language: 'en-US', externalContents: [parentNoticeEn] },
+        ],
+      },
+      { i18n: [{ language: 'en-US', externalContents: [childLinkEn] }] },
+    ] as unknown as ArianeeProductCertificateI18N[]);
+
+    expect(result.i18n).toEqual([
+      { language: 'fr-FR', externalContents: [parentNoticeFr] },
+      { language: 'en-US', externalContents: [parentNoticeEn, childLinkEn] },
+    ]);
+  });
+});

--- a/packages/utils/src/lib/mergeSmartAssetAndParentSmartAsset/mergeSmartAssetAndParentSmartAsset.ts
+++ b/packages/utils/src/lib/mergeSmartAssetAndParentSmartAsset/mergeSmartAssetAndParentSmartAsset.ts
@@ -1,19 +1,120 @@
 import { ArianeeProductCertificateI18N } from '@arianee/common-types';
 
+type MergeableI18N = {
+  language?: string;
+  externalContents?: unknown[];
+  [key: string]: unknown;
+};
+
+type MergeableContent = {
+  externalContents?: unknown[];
+  i18n?: MergeableI18N[];
+  [key: string]: unknown;
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, i) => deepEqual(item, b[i]));
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    return (
+      aKeys.length === bKeys.length &&
+      aKeys.every((key) => deepEqual(a[key], b[key]))
+    );
+  }
+  return false;
+};
+
+/**
+ * Concatenates parent and child externalContents (parent entries first) and
+ * removes strictly identical duplicates (ARI-3292).
+ */
+const concatExternalContents = (
+  parent: unknown[],
+  child: unknown[]
+): unknown[] => {
+  const result = [...parent];
+  for (const entry of child) {
+    if (!result.some((existing) => deepEqual(existing, entry))) {
+      result.push(entry);
+    }
+  }
+  return result;
+};
+
+/**
+ * Merges a single parent/child pair: the child overrides the parent's
+ * properties, except externalContents which are concatenated (parent first) at
+ * the root and, recursively, inside each matching i18n language entry. i18n is
+ * merged by language so parent-only languages are kept and child-only languages
+ * are appended (ARI-3292).
+ */
+const mergeContentPair = (
+  parent: MergeableContent,
+  child: MergeableContent
+): MergeableContent => {
+  const result: MergeableContent = { ...parent, ...child };
+
+  if (
+    Array.isArray(parent.externalContents) &&
+    Array.isArray(child.externalContents)
+  ) {
+    result.externalContents = concatExternalContents(
+      parent.externalContents,
+      child.externalContents
+    );
+  }
+
+  if (Array.isArray(parent.i18n) && Array.isArray(child.i18n)) {
+    result.i18n = mergeI18nByLanguage(parent.i18n, child.i18n);
+  }
+
+  return result;
+};
+
+const mergeI18nByLanguage = (
+  parentI18n: MergeableI18N[],
+  childI18n: MergeableI18N[]
+): MergeableI18N[] => {
+  const merged = parentI18n.map((parentLang) => {
+    const childLang = childI18n.find(
+      (lang) => lang?.language === parentLang?.language
+    );
+    return childLang ? mergeContentPair(parentLang, childLang) : parentLang;
+  });
+
+  const childOnlyLanguages = childI18n.filter(
+    (childLang) =>
+      !parentI18n.some(
+        (parentLang) => parentLang?.language === childLang?.language
+      )
+  );
+
+  return [...merged, ...childOnlyLanguages];
+};
+
 /**
  * Merge array of smart asset.
  * Ex: parent nft should be in first position, children last positions.
+ *
+ * The child overrides the parents' scalar properties, but externalContents are
+ * accumulated from the whole chain (parent first, deduplicated) instead of
+ * being overridden, both at the root and per language in i18n (ARI-3292).
  * @param contents
  * @returns
  */
 export function mergeSmartAssetAndParentSmartAsset(
   contents: ArianeeProductCertificateI18N[]
 ): ArianeeProductCertificateI18N {
-  const content: ArianeeProductCertificateI18N = <
-    ArianeeProductCertificateI18N
-  >{};
-  contents.forEach((d) => {
-    Object.assign(content, d);
-  });
-  return content;
+  return contents.reduce<MergeableContent>(
+    (merged, content) =>
+      mergeContentPair(merged, (content ?? {}) as unknown as MergeableContent),
+    {}
+  ) as unknown as ArianeeProductCertificateI18N;
 }


### PR DESCRIPTION
## Quoi

`mergeSmartAssetAndParentSmartAsset` (`@arianee/utils`, exporté publiquement) fusionnait parent/enfant avec un `Object.assign` shallow : les `externalContents` (et le tableau `i18n`) de l'enfant écrasaient entièrement ceux du parent. Désormais les `externalContents` sont **concaténés** (parent d'abord, dédoublonnage des entrées identiques).

Cohérence avec le fix backend [ArianeeBrandDataHub#3846](https://github.com/Arianee/ArianeeBrandDataHub/pull/3846) et le fix wallet-api [wallet-api#133](https://github.com/Arianee/wallet-api/pull/133). La fonction n'est pas utilisée à l'intérieur du SDK lui-même, mais elle fait partie de l'API publique `@arianee/utils` et doit avoir la même sémantique pour les consommateurs externes.

## Comment

Remplacement de l'`Object.assign` par un merge dédié, sans nouvelle dépendance :
- l'enfant surcharge les propriétés scalaires du parent ;
- `externalContents` concaténés (parent d'abord, dédoublonnage par égalité profonde) à la racine et par langue dans `i18n` ;
- `i18n` mergé par langue (langues parent seules conservées, langues enfant seules ajoutées) ;
- accumulation sur toute la chaîne de parents.

## Tests

- Nouveau `mergeSmartAssetAndParentSmartAsset.spec.ts` : 6 cas (override scalaire, concat, parent seul, dédoublonnage, multi-niveaux, i18n par langue).
- `nx test/lint/build utils` verts.

Ticket : [ARI-3292](https://linear.app/arianee/issue/ARI-3292/gestion-external-content-dpp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)