### PR TITLE
ci: push semver version tag on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
             git commit -m "[SKIP CI]chore: bump to version $version"
             git tag -a "$version" -m ""
             git push origin "release/$version"
+            git push origin "$version"
             ./scripts/publish.sh
             git checkout main
             git reset --hard origin/main


### PR DESCRIPTION
## What

Add `git push origin "$version"` to the `publish_on_npm` job in `.circleci/config.yml` so the version tag is actually pushed to the remote.

## Why

The CI already created an annotated tag (`git tag -a "$version"`) during the release, but **only the `release/$version` branch was pushed** — the tag itself was never sent to origin. As a result there were no version tags on the remote at all (`git ls-remote --tags origin` returned empty).

## Change

```yaml
git tag -a "$version" -m ""
git push origin "release/$version"
git push origin "$version"      # ← added
```

The tag keeps the conventional `v` prefix (e.g. `v1.108.0`) and points to the `[SKIP CI]chore: bump to version $version` commit, giving a clean, stable per-version tag that is independent of the subsequent `main` rebase/force-push.

## Notes for reviewer

- The tag is pushed **before** `./scripts/publish.sh`, so even if the npm publish fails, the pushed tag stays consistent with what was committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)